### PR TITLE
feat(react): backport React 18 transitions

### DIFF
--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -52,6 +52,10 @@ type React_Node = ReactTypes.React_Node
 -- ROBLOX deviation START: add binding support
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 -- ROBLOX deviation END
 -- ROBLOX deviation START: fix import
 -- local reactReconcilerSrcReactInternalTypesModule =
@@ -217,8 +221,7 @@ local function getPrimitiveStackCache(): Map<string, Array<any>>
 end
 local currentHook: nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook =
 	nil
-local function nextHook(
-): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
+local function nextHook(): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
 	local hook = currentHook
 	if hook ~= nil then
 		currentHook = hook.next
@@ -444,33 +447,28 @@ local function useMutableSource<Source, Snapshot>(
 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
 	return value
 end
--- ROBLOX deviation START: enable these once they are fully enabled in the Dispatcher type and in ReactFiberHooks' myriad dispatchers
--- local function useTransition(
--- ): any --[[ ROBLOX TODO: Unhandled node for type: TupleTypeAnnotation ]] --[[ [(() => void) => void, boolean] ]]
--- 	-- useTransition() composes multiple hooks internally.
--- 	-- Advance the current hook index the same number of times
--- 	-- so that subsequent hooks have the right memoized state.
--- 	nextHook() -- State
--- 	nextHook() -- Callback
--- 	table.insert(
--- 		hookLog,
--- 		{ primitive = "Transition", stackError = Error.new(), value = nil }
--- 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
--- 	return { function(callback) end, false }
--- end
--- local function useDeferredValue<T>(value: T): T
--- 	-- useDeferredValue() composes multiple hooks internally.
--- 	-- Advance the current hook index the same number of times
--- 	-- so that subsequent hooks have the right memoized state.
--- 	nextHook() -- State
--- 	nextHook() -- Effect
--- 	table.insert(
--- 		hookLog,
--- 		{ primitive = "DeferredValue", stackError = Error.new(), value = value }
--- 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
--- 	return value
--- end
--- ROBLOX deviation END
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/ReactDebugHooks.js#L298-L315
+-- ROBLOX deviation: Luau represents React's tuple as multiple return values.
+local function useTransition(): (boolean, StartTransition)
+	nextHook() -- State
+	nextHook() -- Callback
+	table.insert(
+		hookLog,
+		{ primitive = "Transition", stackError = Error.new(), value = nil }
+	)
+	return false, function(_callback, _options) end
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/72ebc703ac8abacd44fdeb1e3d66eb28b75e5a5b/packages/react-debug-tools/src/ReactDebugHooks.js#L312-L322
+local function useDeferredValue<T>(value: T): T
+	local hook = nextHook()
+	table.insert(hookLog, {
+		primitive = "DeferredValue",
+		stackError = Error.new(),
+		value = if hook ~= nil then hook.memoizedState else value,
+	})
+	return value
+end
 local function useOpaqueIdentifier(): OpaqueIDType | void
 	local hook = nextHook() -- State
 	-- ROBLOX deviation START: simplify
@@ -531,13 +529,9 @@ Dispatcher = {
 	-- useState = useState,
 	useState = useState :: any,
 	-- ROBLOX deviation END
-	-- ROBLOX deviation START: not implemented
-	-- useTransition = useTransition,
-	-- ROBLOX deviation END
+	useTransition = useTransition,
 	useMutableSource = useMutableSource,
-	-- ROBLOX deviation START: not implemented
-	-- useDeferredValue = useDeferredValue,
-	-- ROBLOX deviation END
+	useDeferredValue = useDeferredValue,
 	useOpaqueIdentifier = useOpaqueIdentifier,
 } -- Inspect
 export type HooksNode = {

--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -52,10 +52,7 @@ type React_Node = ReactTypes.React_Node
 -- ROBLOX deviation START: add binding support
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 -- ROBLOX deviation END
 -- ROBLOX deviation START: fix import
 -- local reactReconcilerSrcReactInternalTypesModule =
@@ -221,7 +218,8 @@ local function getPrimitiveStackCache(): Map<string, Array<any>>
 end
 local currentHook: nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook =
 	nil
-local function nextHook(): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
+local function nextHook(
+): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
 	local hook = currentHook
 	if hook ~= nil then
 		currentHook = hook.next

--- a/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
+++ b/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
@@ -538,14 +538,10 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
-	-- ROBLOX deviation START: unstable_useTransition is not implemented
-	-- it("should support composite useTransition hook", function()
-	it.skip("should support composite useTransition hook", function()
-		-- ROBLOX deviation END
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+	it("should support composite useTransition hook", function()
 		local function Foo(props)
-			-- ROBLOX deviation START: not supported
-			-- React.unstable_useTransition()
-			-- ROBLOX deviation END
+			React.useTransition()
 			local memoizedValue = React.useMemo(function()
 				return "hello"
 			end, {})
@@ -585,23 +581,19 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
-	-- ROBLOX deviation START: unstable_useDeferredValue not implemented
-	-- it("should support composite useDeferredValue hook", function()
-	it.skip("should support composite useDeferredValue hook", function()
-		-- ROBLOX deviation END
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/72ebc703ac8abacd44fdeb1e3d66eb28b75e5a5b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js#L582-L626
+	it("should support composite useDeferredValue hook", function()
 		local function Foo(props)
-			-- ROBLOX deviation START: not implemented
-			-- React.unstable_useDeferredValue("abc", { timeoutMs = 500 })
-			-- ROBLOX deviation END
-			local state = React.useState(function()
+			React.useDeferredValue("abc")
+			local memoizedValue = React.useMemo(function()
 				return "hello"
-				-- ROBLOX deviation START: useState returns 2 values
-				-- end, {})[1]
 			end, {})
-			-- ROBLOX deviation END
+			React.useMemo(function()
+				return "world"
+			end, {})
 			-- ROBLOX deviation START: use Frame instead
-			-- return React.createElement("div", nil, state)
-			return React.createElement("Frame", nil, state)
+			-- return React.createElement("div", nil, memoizedValue)
+			return React.createElement("Frame", nil, memoizedValue)
 			-- ROBLOX deviation END
 		end
 		local renderer = ReactTestRenderer.create(React.createElement(Foo, nil))
@@ -626,9 +618,16 @@ describe("ReactHooksInspectionIntegration", function()
 				-- id = 1,
 				id = 2,
 				-- ROBLOX deviation END
-				isStateEditable = true,
-				name = "State",
+				isStateEditable = false,
+				name = "Memo",
 				value = "hello",
+				subHooks = {},
+			},
+			{
+				id = 3,
+				isStateEditable = false,
+				name = "Memo",
+				value = "world",
 				subHooks = {},
 			},
 		})

--- a/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
+++ b/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
@@ -75,6 +75,7 @@ local ReplaceState = ReactUpdateQueue.ReplaceState
 local ForceUpdate = ReactUpdateQueue.ForceUpdate
 local initializeUpdateQueue = ReactUpdateQueue.initializeUpdateQueue
 local cloneUpdateQueue = ReactUpdateQueue.cloneUpdateQueue
+local entangleTransitions = ReactUpdateQueue.entangleTransitions
 local NoLanes = ReactFiberLane.NoLanes
 
 local ReactFiberContext = require(script.Parent["ReactFiberContext.new"])
@@ -267,7 +268,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then
@@ -299,7 +303,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then
@@ -330,7 +337,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -45,6 +45,8 @@ type MutableSourceSubscribeFn<Source, Snapshot> = ReactTypes.MutableSourceSubscr
 	Source,
 	Snapshot
 >
+type StartTransition = ReactTypes.StartTransition
+type StartTransitionOptions = ReactTypes.StartTransitionOptions
 
 local ReactInternalTypes = require(script.Parent.ReactInternalTypes)
 type Fiber = ReactInternalTypes.Fiber
@@ -73,15 +75,12 @@ local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffect
 local DebugTracingMode = require(script.Parent.ReactTypeOfMode).DebugTracingMode
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
-local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
+local intersectLanes = ReactFiberLane.intersectLanes
 local removeLanes = ReactFiberLane.removeLanes
 local markRootEntangled = ReactFiberLane.markRootEntangled
 local markRootMutableRead = ReactFiberLane.markRootMutableRead
-local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
-local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
-local higherLanePriority = ReactFiberLane.higherLanePriority
 local includesOnlyNonUrgentLanes = ReactFiberLane.includesOnlyNonUrgentLanes
 local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
 local isTransitionLane = ReactFiberLane.isTransitionLane
@@ -123,12 +122,11 @@ local function is(x: any, y: any)
 end
 local markWorkInProgressReceivedUpdate =
 	require(script.Parent["ReactFiberBeginWork.new"]).markWorkInProgressReceivedUpdate :: any
--- local {
---   UserBlockingPriority,
---   NormalPriority,
---   runWithPriority,
---   getCurrentPriorityLevel,
--- } = require(script.Parent.SchedulerWithReactIntegration.new)
+local SchedulerWithReactIntegration =
+	require(script.Parent["SchedulerWithReactIntegration.new"])
+local UserBlockingPriority = SchedulerWithReactIntegration.UserBlockingPriority
+local getCurrentPriorityLevel = SchedulerWithReactIntegration.getCurrentPriorityLevel
+local runWithPriority = SchedulerWithReactIntegration.runWithPriority
 local getIsHydrating =
 	require(script.Parent["ReactFiberHydrationContext.new"]).getIsHydrating
 -- local {
@@ -209,10 +207,6 @@ export type FunctionComponentUpdateQueue = {
 type BasicStateAction<S> = ((S) -> S) | S
 
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 local exports: any = {}
 
@@ -1629,18 +1623,16 @@ updateDeferredValueImpl = function<T>(hook: Hook, prevValue: T, value: T): T
 end
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L1974-L2061
--- ROBLOX deviation: React 17 exposes update lane priorities instead of React 18 event priorities.
+-- ROBLOX deviation: React 17 selects update lanes from Scheduler priority.
 local function startTransition(
 	setPending: Dispatch<BasicStateAction<boolean>>,
 	callback: () -> (),
 	options: StartTransitionOptions?
 ): ()
-	local previousPriority = getCurrentUpdateLanePriority()
-	setCurrentUpdateLanePriority(
-		higherLanePriority(previousPriority, InputContinuousLanePriority)
-	)
-
-	setPending(true)
+	local pendingPriority = math.max(getCurrentPriorityLevel(), UserBlockingPriority)
+	runWithPriority(pendingPriority, function()
+		setPending(true)
+	end)
 
 	local prevTransition = ReactCurrentBatchConfig.transition
 	ReactCurrentBatchConfig.transition = {}
@@ -1661,7 +1653,6 @@ local function startTransition(
 		callback()
 	end)
 
-	setCurrentUpdateLanePriority(previousPriority)
 	ReactCurrentBatchConfig.transition = prevTransition
 
 	if __DEV__ and currentTransition._updatedFibers ~= nil then
@@ -1676,7 +1667,7 @@ local function startTransition(
 	end
 
 	if not ok then
-		error(result)
+		error(result, 0)
 	end
 end
 
@@ -1811,8 +1802,7 @@ local function entangleTransitionUpdate<S, A>(
 	lane: Lane
 ): ()
 	if isTransitionLane(lane) then
-		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
-		local queueLanes = bit32.band(queue.lanes, root.pendingLanes)
+		local queueLanes = intersectLanes(queue.lanes, root.pendingLanes)
 		local newQueueLanes = mergeLanes(queueLanes, lane)
 		queue.lanes = newQueueLanes
 		markRootEntangled(root, newQueueLanes)

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -21,6 +21,7 @@ local LuauPolyfill = require(Packages.LuauPolyfill)
 local Array = LuauPolyfill.Array
 local Error = LuauPolyfill.Error
 local Object = LuauPolyfill.Object
+local Set = LuauPolyfill.Set
 
 local __DEV__ = ReactGlobals.__DEV__ :: boolean
 
@@ -65,22 +66,25 @@ local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
 local enableDebugTracing: boolean? = ReactFeatureFlags.enableDebugTracing
 local enableSchedulingProfiler: boolean? = ReactFeatureFlags.enableSchedulingProfiler
 local enableNewReconciler: boolean? = ReactFeatureFlags.enableNewReconciler
--- local decoupleUpdatePriorityFromScheduler = ReactFeatureFlags.decoupleUpdatePriorityFromScheduler
+local enableTransitionTracing: boolean = ReactFeatureFlags.enableTransitionTracing
 local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffects
 
 -- local ReactTypeOfMode = require(script.Parent.ReactTypeOfMode)
 local DebugTracingMode = require(script.Parent.ReactTypeOfMode).DebugTracingMode
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
--- local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
+local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
 local removeLanes = ReactFiberLane.removeLanes
 local markRootEntangled = ReactFiberLane.markRootEntangled
 local markRootMutableRead = ReactFiberLane.markRootMutableRead
--- local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
--- local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
--- local higherLanePriority = ReactFiberLane.higherLanePriority
+local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
+local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
+local higherLanePriority = ReactFiberLane.higherLanePriority
+local includesOnlyNonUrgentLanes = ReactFiberLane.includesOnlyNonUrgentLanes
+local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
+local isTransitionLane = ReactFiberLane.isTransitionLane
 -- local DefaultLanePriority = ReactFiberLane.DefaultLanePriority
 local ReactFiberNewContext = require(script.Parent["ReactFiberNewContext.new"])
 local readContext = ReactFiberNewContext.readContext
@@ -149,7 +153,7 @@ local markStateUpdateScheduled =
 	require(script.Parent.SchedulingProfiler).markStateUpdateScheduled
 
 local ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher
--- local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
+local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 local FFlagReactCleanQueueOnUpdateBailout =
 	require(Packages.SafeFlags).createGetFFlag("ReactCleanQueueOnUpdateBailout")()
@@ -168,6 +172,7 @@ type Update<S, A> = {
 
 type UpdateQueue<S, A> = {
 	pending: Update<S, A> | nil,
+	lanes: Lanes,
 	dispatch: ((A) -> ...any) | nil,
 	lastRenderedReducer: ((S, A) -> S) | nil,
 	lastRenderedState: S | nil,
@@ -204,6 +209,10 @@ export type FunctionComponentUpdateQueue = {
 type BasicStateAction<S> = ((S) -> S) | S
 
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 local exports: any = {}
 
@@ -651,6 +660,7 @@ function mountReducer<S, I, A>(
 
 	local queue: UpdateQueue<S, A> = {
 		pending = nil,
+		lanes = NoLanes,
 		dispatch = nil,
 		lastRenderedReducer = reducer,
 		lastRenderedState = initialState :: any,
@@ -717,6 +727,11 @@ function updateReducer<S, I, A>(
 		baseQueue = pendingQueue
 		current.baseQueue = baseQueue
 		queue.pending = nil
+	end
+
+	if baseQueue == nil then
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L902-L904
+		queue.lanes = NoLanes
 	end
 
 	if baseQueue ~= nil then
@@ -1113,6 +1128,7 @@ function useMutableSource<Source, Snapshot>(
 		-- including any interleaving updates that occur.
 		local newQueue = {
 			pending = nil,
+			lanes = NoLanes,
 			dispatch = nil,
 			lastRenderedReducer = basicStateReducer,
 			lastRenderedState = snapshot,
@@ -1185,6 +1201,7 @@ function mountState<S>(initialState: (() -> S) | S): (S, Dispatch<BasicStateActi
 	hook.memoizedState = hook.baseState
 	local queue: UpdateQueue<S, BasicStateAction<S>> = {
 		pending = nil,
+		lanes = NoLanes,
 		dispatch = nil,
 		lastRenderedReducer = nil, --basicStateReducer,
 		lastRenderedState = initialState :: any,
@@ -1564,134 +1581,128 @@ function updateMemo<T...>(nextCreate: () -> T..., deps: Array<any> | nil): ...an
 	return unpack(nextValue)
 end
 
--- function mountDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = mountState(value)
---   mountEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+-- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/ReactFiberHooks.new.js#L1933-L2001
+local function mountDeferredValue<T>(value: T): T
+	local hook = mountWorkInProgressHook()
+	hook.memoizedState = value
+	return value
+end
 
--- function updateDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = updateState(value)
---   updateEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+local updateDeferredValueImpl
 
--- function rerenderDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = rerenderState(value)
---   updateEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+local function updateDeferredValue<T>(value: T): T
+	local hook = updateWorkInProgressHook()
+	local prevValue: T = currentHook.memoizedState
+	return updateDeferredValueImpl(hook, prevValue, value)
+end
 
--- function startTransition(setPending, callback)
---   local priorityLevel = getCurrentPriorityLevel()
---   if decoupleUpdatePriorityFromScheduler)
---     local previousLanePriority = getCurrentUpdateLanePriority()
---     setCurrentUpdateLanePriority(
---       higherLanePriority(previousLanePriority, InputContinuousLanePriority),
---     )
+local function rerenderDeferredValue<T>(value: T): T
+	local hook = updateWorkInProgressHook()
+	if currentHook == nil then
+		hook.memoizedState = value
+		return value
+	else
+		local prevValue: T = currentHook.memoizedState
+		return updateDeferredValueImpl(hook, prevValue, value)
+	end
+end
 
---     runWithPriority(
---       priorityLevel < UserBlockingPriority
---         ? UserBlockingPriority
---         : priorityLevel,
---       () => {
---         setPending(true)
---       },
---     )
+updateDeferredValueImpl = function<T>(hook: Hook, prevValue: T, value: T): T
+	local shouldDeferValue = not includesOnlyNonUrgentLanes(renderLanes)
+	if shouldDeferValue then
+		if not is(value, prevValue) then
+			local deferredLane = claimNextTransitionLane()
+			currentlyRenderingFiber.lanes =
+				mergeLanes(currentlyRenderingFiber.lanes, deferredLane)
+			markSkippedUpdateLanes(deferredLane)
+			hook.baseState = true
+		end
+		return prevValue
+	else
+		if hook.baseState then
+			hook.baseState = false
+			markWorkInProgressReceivedUpdate()
+		end
+		hook.memoizedState = value
+		return value
+	end
+end
 
---     -- TODO: Can remove this. Was only necessary because we used to give
---     -- different behavior to transitions without a config object. Now they are
---     -- all treated the same.
---     setCurrentUpdateLanePriority(DefaultLanePriority)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L1974-L2061
+-- ROBLOX deviation: React 17 exposes update lane priorities instead of React 18 event priorities.
+local function startTransition(
+	setPending: Dispatch<BasicStateAction<boolean>>,
+	callback: () -> (),
+	options: StartTransitionOptions?
+): ()
+	local previousPriority = getCurrentUpdateLanePriority()
+	setCurrentUpdateLanePriority(
+		higherLanePriority(previousPriority, InputContinuousLanePriority)
+	)
 
---     runWithPriority(
---       priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
---       () => {
---         local prevTransition = ReactCurrentBatchConfig.transition
---         ReactCurrentBatchConfig.transition = 1
---         try {
---           setPending(false)
---           callback()
---         } finally {
---           if decoupleUpdatePriorityFromScheduler)
---             setCurrentUpdateLanePriority(previousLanePriority)
---           end
---           ReactCurrentBatchConfig.transition = prevTransition
---         end
---       },
---     )
---   } else {
---     runWithPriority(
---       priorityLevel < UserBlockingPriority
---         ? UserBlockingPriority
---         : priorityLevel,
---       () => {
---         setPending(true)
---       },
---     )
+	setPending(true)
 
---     runWithPriority(
---       priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
---       () => {
---         local prevTransition = ReactCurrentBatchConfig.transition
---         ReactCurrentBatchConfig.transition = 1
---         try {
---           setPending(false)
---           callback()
---         } finally {
---           ReactCurrentBatchConfig.transition = prevTransition
---         end
---       },
---     )
---   end
--- end
+	local prevTransition = ReactCurrentBatchConfig.transition
+	ReactCurrentBatchConfig.transition = {}
+	local currentTransition = ReactCurrentBatchConfig.transition
 
--- function mountTransition(): [(() => void) => void, boolean] {
---   local [isPending, setPending] = mountState(false)
---   -- The `start` method can be stored on a ref, since `setPending`
---   -- never changes.
---   local start = startTransition.bind(null, setPending)
---   mountRef(start)
---   return [start, isPending]
--- end
+	if enableTransitionTracing and options ~= nil and options.name ~= nil then
+		currentTransition.name = options.name
+		-- ROBLOX deviation: Transition tracing clocks are not available in React Lua.
+		currentTransition.startTime = -1
+	end
 
--- function updateTransition(): [(() => void) => void, boolean] {
---   local [isPending] = updateState(false)
---   local startRef = updateRef()
---   local start: (() => void) => void = (startRef.current: any)
---   return [start, isPending]
--- end
+	if __DEV__ then
+		currentTransition._updatedFibers = Set.new()
+	end
 
--- function rerenderTransition(): [(() => void) => void, boolean] {
---   local [isPending] = rerenderState(false)
---   local startRef = updateRef()
---   local start: (() => void) => void = (startRef.current: any)
---   return [start, isPending]
--- end
+	local ok, result = pcall(function()
+		setPending(false)
+		callback()
+	end)
+
+	setCurrentUpdateLanePriority(previousPriority)
+	ReactCurrentBatchConfig.transition = prevTransition
+
+	if __DEV__ and currentTransition._updatedFibers ~= nil then
+		if prevTransition == nil and currentTransition._updatedFibers.size > 10 then
+			console.warn(
+				"Detected a large number of updates inside startTransition. "
+					.. "If this is due to a subscription please re-write it to use React provided hooks. "
+					.. "Otherwise concurrent mode guarantees are off the table."
+			)
+		end
+		currentTransition._updatedFibers:clear()
+	end
+
+	if not ok then
+		error(result)
+	end
+end
+
+local function mountTransition(): (boolean, StartTransition)
+	local isPending, setPending = mountState(false)
+	local start: StartTransition = function(callback, options)
+		startTransition(setPending, callback, options)
+	end
+	local hook = mountWorkInProgressHook()
+	hook.memoizedState = start
+	return isPending, start
+end
+
+local function updateTransition(): (boolean, StartTransition)
+	local isPending = updateState(false)
+	local hook = updateWorkInProgressHook()
+	local start: StartTransition = hook.memoizedState
+	return isPending, start
+end
+
+local function rerenderTransition(): (boolean, StartTransition)
+	local isPending = rerenderState(false)
+	local hook = updateWorkInProgressHook()
+	local start: StartTransition = hook.memoizedState
+	return isPending, start
+end
 
 local isUpdatingOpaqueValueInRenderPhase = false
 exports.getIsUpdatingOpaqueValueInRenderPhaseInDEV = function(): boolean?
@@ -1791,6 +1802,21 @@ end
 function rerenderOpaqueIdentifier(): OpaqueIDType
 	local id, _ = rerenderState(nil)
 	return id
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L2338-L2361
+local function entangleTransitionUpdate<S, A>(
+	root: FiberRoot,
+	queue: UpdateQueue<S, A>,
+	lane: Lane
+): ()
+	if isTransitionLane(lane) then
+		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
+		local queueLanes = bit32.band(queue.lanes, root.pendingLanes)
+		local newQueueLanes = mergeLanes(queueLanes, lane)
+		queue.lanes = newQueueLanes
+		markRootEntangled(root, newQueueLanes)
+	end
 end
 
 function dispatchAction<S, A>(fiber: Fiber, queue: UpdateQueue<S, A>, action: A, ...): ()
@@ -1906,7 +1932,10 @@ function dispatchAction<S, A>(fiber: Fiber, queue: UpdateQueue<S, A>, action: A,
 				warnIfNotCurrentlyActingUpdatesInDEV(fiber)
 			end
 		end
-		scheduleUpdateOnFiber(fiber, lane, eventTime)
+		local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+		if root ~= nil then
+			entangleTransitionUpdate(root, queue, lane)
+		end
 	end
 
 	if __DEV__ then
@@ -1940,8 +1969,8 @@ local ContextOnlyDispatcher: Dispatcher = {
 	useBinding = throwInvalidHookError :: any,
 	useState = throwInvalidHookError :: any,
 	useDebugValue = throwInvalidHookError :: any,
-	-- useDeferredValue = throwInvalidHookError,
-	-- useTransition = throwInvalidHookError,
+	useDeferredValue = throwInvalidHookError :: any,
+	useTransition = throwInvalidHookError :: any,
 	useMutableSource = throwInvalidHookError :: any,
 	useOpaqueIdentifier = throwInvalidHookError :: any,
 
@@ -1964,8 +1993,8 @@ local HooksDispatcherOnMount: Dispatcher = {
 	useBinding = mountBinding,
 	useState = mountState,
 	useDebugValue = mountDebugValue,
-	-- useDeferredValue = mountDeferredValue,
-	-- useTransition = mountTransition,
+	useDeferredValue = mountDeferredValue,
+	useTransition = mountTransition,
 	useMutableSource = mountMutableSource,
 	useOpaqueIdentifier = mountOpaqueIdentifier,
 
@@ -1987,8 +2016,8 @@ local HooksDispatcherOnUpdate: Dispatcher = {
 	useBinding = updateBinding,
 	useState = updateState,
 	useDebugValue = updateDebugValue,
-	-- useDeferredValue = updateDeferredValue,
-	-- useTransition = updateTransition,
+	useDeferredValue = updateDeferredValue,
+	useTransition = updateTransition,
 	useMutableSource = updateMutableSource,
 	useOpaqueIdentifier = updateOpaqueIdentifier,
 
@@ -2010,8 +2039,8 @@ local HooksDispatcherOnRerender: Dispatcher = {
 	useBinding = updateBinding,
 	useState = rerenderState,
 	useDebugValue = updateDebugValue,
-	-- useDeferredValue = rerenderDeferredValue,
-	-- useTransition = rerenderTransition,
+	useDeferredValue = rerenderDeferredValue,
+	useTransition = rerenderTransition,
 	useMutableSource = updateMutableSource,
 	useOpaqueIdentifier = rerenderOpaqueIdentifier,
 
@@ -2157,16 +2186,16 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       mountHookTypesDev()
-		--       return mountDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       mountHookTypesDev()
-		--       return mountTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			mountHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			mountHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2306,16 +2335,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return mountDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return mountTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2454,16 +2483,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return updateDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return updateTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return updateDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return updateTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2603,16 +2632,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return rerenderDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return rerenderTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return rerenderDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return rerenderTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2763,18 +2792,18 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		-- useDeferredValue<T>(value: T): T {
-		--   currentHookNameInDev = 'useDeferredValue'
-		--   warnInvalidHookAccess()
-		--   mountHookTypesDev()
-		--   return mountDeferredValue(value)
-		-- },
-		-- useTransition(): [(() => void) => void, boolean] {
-		--   currentHookNameInDev = 'useTransition'
-		--   warnInvalidHookAccess()
-		--   mountHookTypesDev()
-		--   return mountTransition()
-		-- },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			mountHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			mountHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2928,18 +2957,18 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return updateDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return updateTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return updateDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return updateTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -3093,18 +3122,18 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return rerenderDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return rerenderTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return rerenderDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return rerenderTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<

--- a/modules/react-reconciler/src/ReactFiberLane.lua
+++ b/modules/react-reconciler/src/ReactFiberLane.lua
@@ -113,6 +113,20 @@ local TransitionHydrationLane: Lane = --[[              ]]
 	0b0000000000000000001000000000000
 local TransitionLanes: Lanes = --[[                     ]]
 	0b0000000001111111110000000000000
+local TransitionLane1: Lane = bit32.band(TransitionLanes, -TransitionLanes)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/422d102bd58ab16f93b6d84a2a25c759b6a1288f/packages/react-reconciler/src/ReactFiberLane.new.js#L58-L62
+-- ROBLOX deviation: React 17 has lane families for each urgent priority.
+local UrgentLanes: Lanes = bit32.bor(
+	SyncLane,
+	SyncBatchedLane,
+	InputDiscreteHydrationLane,
+	InputDiscreteLanes,
+	InputContinuousHydrationLane,
+	InputContinuousLanes,
+	DefaultHydrationLane,
+	DefaultLanes
+)
 
 local RetryLanes: Lanes = --[[                          ]]
 	0b0000011110000000000000000000000
@@ -545,6 +559,17 @@ local function includesOnlyTransitions(lanes: Lanes)
 end
 exports.includesOnlyTransitions = includesOnlyTransitions
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/422d102bd58ab16f93b6d84a2a25c759b6a1288f/packages/react-reconciler/src/ReactFiberLane.new.js#L527-L531
+local function includesOnlyNonUrgentLanes(lanes: Lanes): boolean
+	return bit32.band(lanes, UrgentLanes) == NoLanes
+end
+exports.includesOnlyNonUrgentLanes = includesOnlyNonUrgentLanes
+
+local function isTransitionLane(lane: Lane): boolean
+	return bit32.band(lane, TransitionLanes) ~= NoLanes
+end
+exports.isTransitionLane = isTransitionLane
+
 -- deviation: pre-declare pickArbitraryLane to keep ordering
 local pickArbitraryLane
 
@@ -588,7 +613,7 @@ local function findUpdateLane(lanePriority: LanePriority, wipLanes: Lanes): Lane
 		end
 		return lane
 	elseif
-		lanePriority == TransitionPriority -- // Should be handled by findTransitionLane instead
+		lanePriority == TransitionPriority -- // Should be handled by claimNextTransitionLane instead
 		or lanePriority == RetryLanePriority -- // Should be handled by findRetryLane instead
 	then
 		-- break
@@ -626,6 +651,19 @@ local function findTransitionLane(wipLanes: Lanes, pendingLanes: Lanes): Lane
 	return lane
 end
 exports.findTransitionLane = findTransitionLane
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberLane.new.js#L491-L503
+local nextTransitionLane: Lane = TransitionLane1
+
+local function claimNextTransitionLane(): Lane
+	local lane = nextTransitionLane
+	nextTransitionLane = bit32.lshift(nextTransitionLane, 1)
+	if bit32.band(nextTransitionLane, TransitionLanes) == NoLanes then
+		nextTransitionLane = TransitionLane1
+	end
+	return lane
+end
+exports.claimNextTransitionLane = claimNextTransitionLane
 
 -- // To ensure consistency across multiple updates in the same event, this should
 -- // be pure function, so that it always returns the same lane for given inputs.

--- a/modules/react-reconciler/src/ReactFiberLane.lua
+++ b/modules/react-reconciler/src/ReactFiberLane.lua
@@ -733,6 +733,11 @@ exports.mergeLanes = (
 	if FFlagReactInlineMergeLanes then bit32.bor else mergeLanes
 ) :: MergeLanes
 
+local function intersectLanes(a: Lanes, b: Lanes): Lanes
+	return bit32.band(a, b)
+end
+exports.intersectLanes = intersectLanes
+
 local function removeLanes(set: Lanes, subset: Lanes | Lane): Lanes
 	return bit32.band(set, bit32.bnot(subset))
 end
@@ -926,15 +931,21 @@ end
 exports.markRootFinished = markRootFinished
 
 local function markRootEntangled(root: FiberRoot, entangledLanes: Lanes)
-	root.entangledLanes = bit32.bor(root.entangledLanes, entangledLanes)
+	local rootEntangledLanes = bit32.bor(root.entangledLanes, entangledLanes)
+	root.entangledLanes = rootEntangledLanes
 
 	local entanglements = root.entanglements
-	local lanes = entangledLanes
+	local lanes = rootEntangledLanes
 	while lanes > 0 do
 		local index = pickArbitraryLaneIndex(lanes)
 		local lane = bit32.lshift(1, index)
 
-		entanglements[index] = bit32.bor(entanglements[index], entangledLanes)
+		if
+			bit32.band(lane, entangledLanes) ~= NoLanes
+			or bit32.band(entanglements[index], entangledLanes) ~= NoLanes
+		then
+			entanglements[index] = bit32.bor(entanglements[index], entangledLanes)
+		end
 
 		lanes = bit32.band(lanes, bit32.bnot(lane))
 	end

--- a/modules/react-reconciler/src/ReactFiberReconciler.new.lua
+++ b/modules/react-reconciler/src/ReactFiberReconciler.new.lua
@@ -101,6 +101,7 @@ local act = ReactFiberWorkLoop.act :: (() -> ()) -> ()
 local ReactUpdateQueue = require(script.Parent["ReactUpdateQueue.new"])
 local createUpdate = ReactUpdateQueue.createUpdate
 local enqueueUpdate = ReactUpdateQueue.enqueueUpdate
+local entangleTransitions = ReactUpdateQueue.entangleTransitions
 local ReactCurrentFiber = require(script.Parent.ReactCurrentFiber)
 local ReactCurrentFiberIsRendering = ReactCurrentFiber.isRendering
 -- deviation: this property would be captured as values instead of bound
@@ -376,7 +377,10 @@ exports.updateContainer = function(
 	end
 
 	enqueueUpdate(current, update)
-	scheduleUpdateOnFiber(current, lane, eventTime)
+	local root = scheduleUpdateOnFiber(current, lane, eventTime)
+	if root ~= nil then
+		entangleTransitions(root, current, lane)
+	end
 
 	return lane
 end

--- a/modules/react-reconciler/src/ReactFiberTransition.lua
+++ b/modules/react-reconciler/src/ReactFiberTransition.lua
@@ -16,7 +16,6 @@ local ReactSharedInternals = require(Packages.Shared).ReactSharedInternals
 local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 return {
-	NoTransition = nil,
 	requestCurrentTransition = function(): { [any]: any }?
 		return ReactCurrentBatchConfig.transition
 	end,

--- a/modules/react-reconciler/src/ReactFiberTransition.lua
+++ b/modules/react-reconciler/src/ReactFiberTransition.lua
@@ -1,5 +1,5 @@
 --!strict
--- ROBLOX upstream: https://github.com/facebook/react/blob/ddd1faa1972b614dfbfae205f2aa4a6c0b39a759/packages/react-reconciler/src/ReactFiberTransition.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberTransition.js
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -16,8 +16,8 @@ local ReactSharedInternals = require(Packages.Shared).ReactSharedInternals
 local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 return {
-	NoTransition = 0,
-	requestCurrentTransition = function(): number
+	NoTransition = nil,
+	requestCurrentTransition = function(): { [any]: any }?
 		return ReactCurrentBatchConfig.transition
 	end,
 }

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -162,7 +162,7 @@ local SyncLane = ReactFiberLane.SyncLane
 local SyncBatchedLane = ReactFiberLane.SyncBatchedLane
 local NoTimestamp = ReactFiberLane.NoTimestamp
 local findUpdateLane = ReactFiberLane.findUpdateLane
-local findTransitionLane = ReactFiberLane.findTransitionLane
+local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
 local findRetryLane = ReactFiberLane.findRetryLane
 local includesSomeLane = ReactFiberLane.includesSomeLane
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
@@ -413,8 +413,6 @@ local workInProgressRootUpdatedLanes: Lanes = ReactFiberLane.NoLanes
 -- Lanes that were pinged (in an interleaved event) during this render.
 local workInProgressRootPingedLanes: Lanes = ReactFiberLane.NoLanes
 
-local mostRecentlyUpdatedRoot: FiberRoot | nil = nil
-
 -- The most recent time we committed a fallback. This lets us ensure a train
 -- model where we don't commit new loading states in too quick succession.
 local globalMostRecentFallbackTime: number = 0
@@ -469,7 +467,8 @@ local spawnedWorkDuringRender: nil | Array<Lane | Lanes> = nil
 -- between the first and second call.
 local currentEventTime: number = NoTimestamp
 local currentEventWipLanes: Lanes = ReactFiberLane.NoLanes
-local currentEventPendingLanes: Lanes = ReactFiberLane.NoLanes
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L407-L408
+local currentEventTransitionLane: Lane = ReactFiberLane.NoLane
 
 local focusedInstanceHandle: nil | Fiber = nil
 local shouldFireAfterActiveInstanceBlur: boolean = false
@@ -539,22 +538,23 @@ exports.requestUpdateLane = function(fiber: Fiber): Lane
 	-- event. Then reset the cached values once we can be sure the event is over.
 	-- Our heuristic for that is whenever we enter a concurrent work loop.
 	--
-	-- We'll do the same for `currentEventPendingLanes` below.
 	if currentEventWipLanes == ReactFiberLane.NoLanes then
 		currentEventWipLanes = workInProgressRootIncludedLanes
 	end
 
-	local isTransition = ReactFiberTransition.requestCurrentTransition()
-		~= ReactFiberTransition.NoTransition
-	if isTransition then
-		if currentEventPendingLanes ~= ReactFiberLane.NoLanes then
-			if mostRecentlyUpdatedRoot ~= nil then
-				currentEventPendingLanes = mostRecentlyUpdatedRoot.pendingLanes
-			else
-				currentEventPendingLanes = ReactFiberLane.NoLanes
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L453-L476
+	local transition = ReactFiberTransition.requestCurrentTransition()
+	if transition ~= ReactFiberTransition.NoTransition then
+		if __DEV__ then
+			if transition._updatedFibers == nil then
+				transition._updatedFibers = Set.new()
 			end
+			transition._updatedFibers:add(fiber)
 		end
-		return findTransitionLane(currentEventWipLanes, currentEventPendingLanes)
+		if currentEventTransitionLane == ReactFiberLane.NoLane then
+			currentEventTransitionLane = claimNextTransitionLane()
+		end
+		return currentEventTransitionLane
 	end
 
 	-- TODO: Remove this dependency on the Scheduler priority.
@@ -723,12 +723,6 @@ exports.scheduleUpdateOnFiber = function(
 		mod.schedulePendingInteractions(root, lane)
 	end
 
-	-- We use this when assigning a lane for a transition inside
-	-- `requestUpdateLane`. We assume it's the same as the root being updated,
-	-- since in the common case of a single root app it probably is. If it's not
-	-- the same root, then it's not a huge deal, we just might batch more stuff
-	-- together more than necessary.
-	mostRecentlyUpdatedRoot = root
 	return root
 end
 
@@ -875,7 +869,7 @@ mod.performConcurrentWorkOnRoot = function(root): (() -> ...any) | nil
 	-- event time. The next update will compute a new event time.
 	currentEventTime = NoTimestamp
 	currentEventWipLanes = ReactFiberLane.NoLanes
-	currentEventPendingLanes = ReactFiberLane.NoLanes
+	currentEventTransitionLane = ReactFiberLane.NoLane
 
 	invariant(
 		bit32.band(executionContext, bit32.bor(RenderContext, CommitContext)) == NoContext,

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -190,7 +190,6 @@ local lanePriorityToSchedulerPriority = ReactFiberLane.lanePriorityToSchedulerPr
 local ReactFiberTransition = require(script.Parent.ReactFiberTransition)
 -- deviation: Use properties directly instead of localizing to avoid 200 limit
 -- local requestCurrentTransition = ReactFiberTransition.requestCurrentTransition
--- local NoTransition = ReactFiberTransition.NoTransition
 
 local ReactFiberUnwindWork = require(script.Parent["ReactFiberUnwindWork.new"]) :: any
 local unwindWork = ReactFiberUnwindWork.unwindWork
@@ -544,7 +543,7 @@ exports.requestUpdateLane = function(fiber: Fiber): Lane
 
 	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L453-L476
 	local transition = ReactFiberTransition.requestCurrentTransition()
-	if transition ~= ReactFiberTransition.NoTransition then
+	if transition ~= nil then
 		if __DEV__ then
 			if transition._updatedFibers == nil then
 				transition._updatedFibers = Set.new()

--- a/modules/react-reconciler/src/ReactInternalTypes.lua
+++ b/modules/react-reconciler/src/ReactInternalTypes.lua
@@ -71,6 +71,7 @@ export type Update<State> = {
 
 export type SharedQueue<State> = {
 	pending: Update<State>?,
+	lanes: Lanes,
 }
 
 export type UpdateQueue<State> = {

--- a/modules/react-reconciler/src/ReactUpdateQueue.new.lua
+++ b/modules/react-reconciler/src/ReactUpdateQueue.new.lua
@@ -107,6 +107,8 @@ local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
+local isTransitionLane = ReactFiberLane.isTransitionLane
+local markRootEntangled = ReactFiberLane.markRootEntangled
 
 -- ROBLOX deviation: lazy instantiate to avoid circular require
 local ReactFiberNewContext --= require(script.Parent["ReactFiberNewContext.new"])
@@ -206,6 +208,7 @@ local function initializeUpdateQueue<State>(fiber: Fiber): ()
 		lastBaseUpdate = nil,
 		shared = {
 			pending = nil,
+			lanes = NoLanes,
 		},
 		effects = nil,
 	}
@@ -308,6 +311,24 @@ local function enqueueUpdate<State>(fiber: Fiber, update: Update<State>)
 	end
 end
 exports.enqueueUpdate = enqueueUpdate
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactUpdateQueue.new.js#L566-L594
+local function entangleTransitions(root: FiberRoot, fiber: Fiber, lane: Lane): ()
+	local updateQueue = fiber.updateQueue
+	if updateQueue == nil then
+		return
+	end
+
+	local sharedQueue: SharedQueue<any> = (updateQueue :: any).shared
+	if isTransitionLane(lane) then
+		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
+		local queueLanes = bit32.band(sharedQueue.lanes, root.pendingLanes)
+		local newQueueLanes = mergeLanes(queueLanes, lane)
+		sharedQueue.lanes = newQueueLanes
+		markRootEntangled(root, newQueueLanes)
+	end
+end
+exports.entangleTransitions = entangleTransitions
 
 local function enqueueCapturedUpdate<State>(workInProgress: Fiber, capturedUpdate: Update<State>)
 	-- Captured updates are updates that are thrown by a child during the render

--- a/modules/react-reconciler/src/ReactUpdateQueue.new.lua
+++ b/modules/react-reconciler/src/ReactUpdateQueue.new.lua
@@ -99,10 +99,12 @@ local console = require(Packages.Shared).console
 
 local ReactInternalTypes = require(script.Parent.ReactInternalTypes)
 type Fiber = ReactInternalTypes.Fiber
+type FiberRoot = ReactInternalTypes.FiberRoot
 type Lane = ReactInternalTypes.Lane
 type Lanes = ReactInternalTypes.Lanes
 
 local ReactFiberLane = require(script.Parent.ReactFiberLane)
+local intersectLanes = ReactFiberLane.intersectLanes
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
@@ -321,8 +323,7 @@ local function entangleTransitions(root: FiberRoot, fiber: Fiber, lane: Lane): (
 
 	local sharedQueue: SharedQueue<any> = (updateQueue :: any).shared
 	if isTransitionLane(lane) then
-		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
-		local queueLanes = bit32.band(sharedQueue.lanes, root.pendingLanes)
+		local queueLanes = intersectLanes(sharedQueue.lanes, root.pendingLanes)
 		local newQueueLanes = mergeLanes(queueLanes, lane)
 		sharedQueue.lanes = newQueueLanes
 		markRootEntangled(root, newQueueLanes)

--- a/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
@@ -1,0 +1,176 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+]]
+
+local Packages = script.Parent.Parent.Parent
+local React
+local ReactNoop
+local Scheduler
+local startTransition
+local useDeferredValue
+local useMemo
+local useState
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+
+local function renderedOutput(originalValue, deferredValue)
+	return React.createElement(
+		"div",
+		nil,
+		React.createElement("div", nil, "Original: " .. tostring(originalValue)),
+		React.createElement("div", nil, "Deferred: " .. tostring(deferredValue))
+	)
+end
+
+describe("ReactDeferredValue", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Scheduler)
+		startTransition = React.startTransition
+		useDeferredValue = React.useDeferredValue
+		useMemo = React.useMemo
+		useState = React.useState
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	local function createChildren(value, deferredValue)
+		local child = useMemo(function()
+			return React.createElement(Text, {
+				text = "Original: " .. tostring(value),
+			})
+		end, { value })
+		local deferredChild = useMemo(function()
+			return React.createElement(Text, {
+				text = "Deferred: " .. tostring(deferredValue),
+			})
+		end, { deferredValue })
+
+		return React.createElement(
+			"div",
+			nil,
+			React.createElement("div", nil, child),
+			React.createElement("div", nil, deferredChild)
+		)
+	end
+
+	local function runDeferredValueSequence(App)
+		local root = ReactNoop.createRoot()
+
+		ReactNoop.act(function()
+			root.render(React.createElement(App, { value = 1 }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "Original: 1", "Deferred: 1" })
+
+		ReactNoop.act(function()
+			root.render(React.createElement(App, { value = 2 }))
+			jestExpect(Scheduler).toFlushUntilNextPaint({ "Original: 2" })
+			jestExpect(Scheduler).toFlushUntilNextPaint({ "Deferred: 2" })
+		end)
+		jestExpect(root).toMatchRenderedOutput(renderedOutput(2, 2))
+
+		ReactNoop.act(function()
+			startTransition(function()
+				root.render(React.createElement(App, { value = 3 }))
+			end)
+			jestExpect(Scheduler).toFlushUntilNextPaint({
+				"Original: 3",
+				"Deferred: 3",
+			})
+		end)
+		jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 3))
+	end
+
+	it(
+		"does not cause an infinite defer loop if the original value isn't memoized",
+		function()
+			local function App(props)
+				local deferredObject = useDeferredValue({ value = props.value })
+				return createChildren(props.value, deferredObject.value)
+			end
+
+			runDeferredValueSequence(App)
+		end
+	)
+
+	it("does not defer during a transition", function()
+		local function App(props)
+			local deferredValue = useDeferredValue(props.value)
+			return createChildren(props.value, deferredValue)
+		end
+
+		runDeferredValueSequence(App)
+	end)
+
+	it("works if there's a render phase update", function()
+		local function App(props)
+			local value, setValue = useState(nil)
+			if value ~= props.value then
+				setValue(props.value)
+			end
+
+			local deferredValue = useDeferredValue(value)
+			return createChildren(value, deferredValue)
+		end
+
+		runDeferredValueSequence(App)
+	end)
+
+	it(
+		"regression test: during urgent update, reuse previous value, not initial value",
+		function()
+			local function App(props)
+				local value, setValue = useState(nil)
+				if value ~= props.value then
+					setValue(props.value)
+				end
+
+				local deferredValue = useDeferredValue(value)
+				return createChildren(value, deferredValue)
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App, { value = 1 }))
+				jestExpect(Scheduler).toFlushUntilNextPaint({
+					"Original: 1",
+					"Deferred: 1",
+				})
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(1, 1))
+			end)
+
+			ReactNoop.act(function()
+				startTransition(function()
+					root.render(React.createElement(App, { value = 2 }))
+				end)
+				jestExpect(Scheduler).toFlushUntilNextPaint({
+					"Original: 2",
+					"Deferred: 2",
+				})
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(2, 2))
+			end)
+
+			ReactNoop.act(function()
+				root.render(React.createElement(App, { value = 3 }))
+				jestExpect(Scheduler).toFlushUntilNextPaint({ "Original: 3" })
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 2))
+				jestExpect(Scheduler).toFlushUntilNextPaint({ "Deferred: 3" })
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 3))
+			end)
+		end
+	)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
@@ -86,6 +86,31 @@ describe("getHighestPriorityPendingLanes", function()
 	end)
 end)
 
+describe("transition lanes", function()
+	it("cycles through each transition lane", function()
+		local firstLane = ReactFiberLane.claimNextTransitionLane()
+		local claimedLanes = { [firstLane] = true }
+
+		jestExpect(ReactFiberLane.isTransitionLane(firstLane)).toBe(true)
+		for _ = 2, 9 do
+			local lane = ReactFiberLane.claimNextTransitionLane()
+			jestExpect(ReactFiberLane.isTransitionLane(lane)).toBe(true)
+			jestExpect(claimedLanes[lane]).toBeNil()
+			claimedLanes[lane] = true
+		end
+
+		jestExpect(ReactFiberLane.claimNextTransitionLane()).toBe(firstLane)
+	end)
+
+	it("distinguishes urgent work from transition work", function()
+		local transitionLane = ReactFiberLane.claimNextTransitionLane()
+		jestExpect(ReactFiberLane.includesOnlyNonUrgentLanes(transitionLane)).toBe(true)
+		jestExpect(ReactFiberLane.includesOnlyNonUrgentLanes(ReactFiberLane.DefaultLanes)).toBe(
+			false
+		)
+	end)
+end)
+
 describe("getNextLanes", function()
 	describe("given no pending lanes", function()
 		local root

--- a/modules/react-reconciler/src/__tests__/ReactHooks-internal.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactHooks-internal.spec.lua
@@ -1438,19 +1438,28 @@ describe("ReactHooks", function()
 		local function useStateHelper(): number
 			return React.useState(0)
 		end
+		local function useDeferredValueHelper()
+			return React.useDeferredValue(0)
+		end
+		local function useTransitionHelper()
+			return React.useTransition()
+		end
 		local orderedHooks: Array<Function> = {
 			useCallbackHelper,
 			useContextHelper,
 			useDebugValueHelper,
+			useDeferredValueHelper,
 			useEffectHelper,
 			useLayoutEffectHelper,
 			useMemoHelper,
 			useReducerHelper,
 			useRefHelper,
 			useStateHelper,
+			useTransitionHelper,
 		}
 		local hooksInList: Array<Function> = {
 			useCallbackHelper,
+			useDeferredValueHelper,
 			useEffectHelper,
 			useImperativeHandleHelper,
 			useLayoutEffectHelper,
@@ -1458,20 +1467,8 @@ describe("ReactHooks", function()
 			useReducerHelper,
 			useRefHelper,
 			useStateHelper,
+			useTransitionHelper,
 		}
-		-- ROBLOX TODO: unflag this when we implement useTransition and useDeferredValueHelper
-		if ReactGlobals.__EXPERIMENTAL__ then
-			-- local function useTransitionHelper()
-			-- 	return React.useTransition()
-			-- end
-			-- local function useDeferredValueHelper()
-			-- 	return React.useDeferredValue(0, { timeoutMs = 1000 })
-			-- end
-			-- table.insert(orderedHooks, useTransitionHelper)
-			-- table.insert(orderedHooks, useDeferredValueHelper)
-			-- table.insert(hooksInList, useTransitionHelper)
-			-- table.insert(hooksInList, useDeferredValueHelper)
-		end
 		local function formatHookNamesToMatchErrorMessage(hookNameA, hookNameB)
 			return string.format(
 				"use%s%s%s",

--- a/modules/react-reconciler/src/__tests__/ReactTransition.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactTransition.spec.lua
@@ -1,0 +1,202 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+]]
+
+local Packages = script.Parent.Parent.Parent
+local React
+local ReactNoop
+local Scheduler
+local Suspense
+local useLayoutEffect
+local useState
+local startTransition
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+
+describe("ReactTransition", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Scheduler)
+		Suspense = React.Suspense
+		useLayoutEffect = React.useLayoutEffect
+		useState = React.useState
+		startTransition = React.startTransition
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	-- ROBLOX deviation: These upstream tests require the unimplemented cache API.
+	it.skip("isPending works even if called from outside an input event", function() end)
+	it.skip(
+		"when multiple transitions update the same queue, only the most recent one is allowed to finish (no intermediate states)",
+		function() end
+	)
+	it.skip(
+		"when multiple transitions update the same queue, only the most recent one is allowed to finish (no intermediate states) (classes)",
+		function() end
+	)
+	it.skip(
+		"when multiple transitions update overlapping queues, all the transitions across all the queues are entangled",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition if a new transition is scheduled",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition when something suspends and we've already bailed out on another transition in a parent",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition when something suspends and a parent component received an interleaved update after its queue was processed",
+		function() end
+	)
+
+	it(
+		"should render normal pri updates scheduled after transitions before transitions",
+		function()
+			local updateTransitionPri
+			local updateNormalPri
+			local function App()
+				local normalPri, setNormalPri = useState(0)
+				local transitionPri, setTransitionPri = useState(0)
+				updateTransitionPri = function()
+					startTransition(function()
+						setTransitionPri(function(n)
+							return n + 1
+						end)
+					end)
+				end
+				updateNormalPri = function()
+					setNormalPri(function(n)
+						return n + 1
+					end)
+				end
+				useLayoutEffect(function()
+					Scheduler.unstable_yieldValue("Commit")
+				end)
+
+				return React.createElement(
+					Suspense,
+					{ fallback = React.createElement(Text, { text = "Loading..." }) },
+					React.createElement(Text, {
+						text = "Transition pri: " .. tostring(transitionPri),
+					}),
+					", ",
+					React.createElement(Text, {
+						text = "Normal pri: " .. tostring(normalPri),
+					})
+				)
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Transition pri: 0",
+				"Normal pri: 0",
+				"Commit",
+			})
+			jestExpect(root).toMatchRenderedOutput("Transition pri: 0, Normal pri: 0")
+
+			ReactNoop.act(function()
+				updateTransitionPri()
+				updateNormalPri()
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Transition pri: 0",
+				"Normal pri: 1",
+				"Commit",
+				"Transition pri: 1",
+				"Normal pri: 1",
+				"Commit",
+			})
+			jestExpect(root).toMatchRenderedOutput("Transition pri: 1, Normal pri: 1")
+		end
+	)
+
+	-- ROBLOX deviation: This upstream test requires the unimplemented cache API.
+	it.skip(
+		"should render normal pri updates before transition suspense retries",
+		function() end
+	)
+
+	it("should not interrupt transitions with normal pri updates", function()
+		local updateNormalPri
+		local updateTransitionPri
+		local function App()
+			local transitionPri, setTransitionPri = useState(0)
+			local normalPri, setNormalPri = useState(0)
+			updateTransitionPri = function()
+				startTransition(function()
+					setTransitionPri(function(n)
+						return n + 1
+					end)
+				end)
+			end
+			updateNormalPri = function()
+				setNormalPri(function(n)
+					return n + 1
+				end)
+			end
+			useLayoutEffect(function()
+				Scheduler.unstable_yieldValue("Commit")
+			end)
+
+			return React.createElement(
+				React.Fragment,
+				nil,
+				React.createElement(Text, {
+					text = "Transition pri: " .. tostring(transitionPri),
+				}),
+				", ",
+				React.createElement(Text, {
+					text = "Normal pri: " .. tostring(normalPri),
+				})
+			)
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(App))
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"Transition pri: 0",
+			"Normal pri: 0",
+			"Commit",
+		})
+		jestExpect(root).toMatchRenderedOutput("Transition pri: 0, Normal pri: 0")
+
+		ReactNoop.act(function()
+			updateTransitionPri()
+			jestExpect(Scheduler).toFlushAndYieldThrough({ "Transition pri: 1" })
+			updateNormalPri()
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"Normal pri: 0",
+			"Commit",
+			"Transition pri: 1",
+			"Normal pri: 1",
+			"Commit",
+		})
+		jestExpect(root).toMatchRenderedOutput("Transition pri: 1, Normal pri: 1")
+	end)
+end)

--- a/modules/react/src/React.lua
+++ b/modules/react/src/React.lua
@@ -27,6 +27,7 @@ local ReactHooks = require(React.ReactHooks)
 local ReactMemo = require(React.ReactMemo)
 local ReactContext = require(React.ReactContext)
 local ReactLazy = require(React.ReactLazy)
+local ReactStartTransition = require(React.ReactStartTransition)
 type LazyComponent<T, P> = ReactLazy.LazyComponent<T, P>
 
 -- ROBLOX DEVIATION: Bindings
@@ -107,6 +108,9 @@ return {
 	-- ROBLOX deviation: bindings support
 	useBinding = ReactHooks.useBinding,
 	useState = ReactHooks.useState,
+	useTransition = ReactHooks.useTransition,
+	useDeferredValue = ReactHooks.useDeferredValue,
+	startTransition = ReactStartTransition.startTransition,
 	--[[
 		Lets you group elements without a wrapper node.
 
@@ -135,9 +139,6 @@ return {
 	-- Deprecated behind disableCreateFactory
 	-- ROBLOX TODO: createFactory,
 	-- Concurrent Mode
-	-- ROBLOX TODO: useTransition,
-	-- ROBLOX TODO: startTransition,
-	-- ROBLOX TODO: useDeferredValue,
 	-- ROBLOX TODO: REACT_SUSPENSE_LIST_TYPE as SuspenseList,
 	unstable_LegacyHidden = ReactSymbols.REACT_LEGACY_HIDDEN_TYPE,
 	-- enableBlocksAPI

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -41,10 +41,7 @@ local ReactCurrentDispatcher =
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 
 -- ROBLOX FIXME Luau: we shouldn't need to explicitly annotate this
 local function resolveDispatcher(): Dispatcher

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -41,6 +41,10 @@ local ReactCurrentDispatcher =
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 -- ROBLOX FIXME Luau: we shouldn't need to explicitly annotate this
 local function resolveDispatcher(): Dispatcher
@@ -289,17 +293,17 @@ exports.useDebugValue = useDebugValue
 
 exports.emptyObject = {}
 
--- ROBLOX TODO: enable useTransition later
--- exports.useTransition = function(): ((() -> ()) -> (), boolean)
--- 	local dispatcher = resolveDispatcher()
--- 	return dispatcher.useTransition()
--- end
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactHooks.js#L164-L176
+-- ROBLOX deviation: Luau represents the tuple as multiple return values.
+exports.useTransition = function(): (boolean, StartTransition)
+	local dispatcher = resolveDispatcher()
+	return dispatcher.useTransition()
+end
 
--- ROBLOX TODO: enable useDeferredValue later
--- exports.useDeferredValue = function<T>(value: T): T
--- 	local dispatcher = resolveDispatcher()
--- 	return dispatcher.useDeferredValue(value)
--- end
+exports.useDeferredValue = function<T>(value: T): T
+	local dispatcher = resolveDispatcher()
+	return dispatcher.useDeferredValue(value)
+end
 
 exports.useOpaqueIdentifier = function(): OpaqueIDType | nil
 	local dispatcher = resolveDispatcher()

--- a/modules/react/src/ReactStartTransition.lua
+++ b/modules/react/src/ReactStartTransition.lua
@@ -1,0 +1,62 @@
+--!strict
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactStartTransition.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+]]
+
+local Packages = script.Parent.Parent
+local ReactGlobals = require(Packages.ReactGlobals)
+local LuauPolyfill = require(Packages.LuauPolyfill)
+local Set = LuauPolyfill.Set
+local console = require(Packages.Shared).console
+local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
+local ReactCurrentBatchConfig =
+	require(Packages.Shared).ReactSharedInternals.ReactCurrentBatchConfig
+
+export type StartTransitionOptions = {
+	name: string?,
+}
+
+local function startTransition(scope: () -> (), options: StartTransitionOptions?): ()
+	local prevTransition = ReactCurrentBatchConfig.transition
+	ReactCurrentBatchConfig.transition = {}
+	local currentTransition = ReactCurrentBatchConfig.transition
+
+	if ReactGlobals.__DEV__ then
+		currentTransition._updatedFibers = Set.new()
+	end
+
+	if ReactFeatureFlags.enableTransitionTracing then
+		if options ~= nil and options.name ~= nil then
+			currentTransition.name = options.name
+			currentTransition.startTime = -1
+		end
+	end
+
+	local ok, result = pcall(scope)
+	ReactCurrentBatchConfig.transition = prevTransition
+
+	if ReactGlobals.__DEV__ and currentTransition._updatedFibers ~= nil then
+		if prevTransition == nil and currentTransition._updatedFibers.size > 10 then
+			console.warn(
+				"Detected a large number of updates inside startTransition. "
+					.. "If this is due to a subscription please re-write it to use React provided hooks. "
+					.. "Otherwise concurrent mode guarantees are off the table."
+			)
+		end
+		currentTransition._updatedFibers:clear()
+	end
+
+	if not ok then
+		error(result)
+	end
+end
+
+return {
+	startTransition = startTransition,
+}

--- a/modules/react/src/ReactStartTransition.lua
+++ b/modules/react/src/ReactStartTransition.lua
@@ -13,14 +13,12 @@ local Packages = script.Parent.Parent
 local ReactGlobals = require(Packages.ReactGlobals)
 local LuauPolyfill = require(Packages.LuauPolyfill)
 local Set = LuauPolyfill.Set
-local console = require(Packages.Shared).console
-local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
-local ReactCurrentBatchConfig =
-	require(Packages.Shared).ReactSharedInternals.ReactCurrentBatchConfig
+local ReactTypes = require(Packages.Shared)
+local console = ReactTypes.console
+local ReactFeatureFlags = ReactTypes.ReactFeatureFlags
+local ReactCurrentBatchConfig = ReactTypes.ReactSharedInternals.ReactCurrentBatchConfig
 
-export type StartTransitionOptions = {
-	name: string?,
-}
+export type StartTransitionOptions = ReactTypes.StartTransitionOptions
 
 local function startTransition(scope: () -> (), options: StartTransitionOptions?): ()
 	local prevTransition = ReactCurrentBatchConfig.transition
@@ -53,7 +51,7 @@ local function startTransition(scope: () -> (), options: StartTransitionOptions?
 	end
 
 	if not ok then
-		error(result)
+		error(result, 0)
 	end
 end
 

--- a/modules/react/src/__tests__/ReactStartTransition.spec.lua
+++ b/modules/react/src/__tests__/ReactStartTransition.spec.lua
@@ -1,0 +1,97 @@
+--!strict
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/__tests__/ReactStartTransition-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+]]
+
+local Packages = script.Parent.Parent.Parent
+
+local React
+local ReactTestRenderer
+local act
+local useState
+local useTransition
+
+local LuauPolyfill = require(Packages.LuauPolyfill)
+local Set = LuauPolyfill.Set
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local jestExpect = JestGlobals.expect
+local jest = JestGlobals.jest
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+
+local SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED = 10
+
+describe("ReactStartTransition", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactTestRenderer = require(Packages.Dev.ReactTestRenderer)
+		act = ReactTestRenderer.unstable_concurrentAct
+		useState = React.useState
+		useTransition = React.useTransition
+	end)
+
+	it("Warns if a suspicious number of fibers are updated inside startTransition", function()
+		local subs = Set.new()
+		local function useUserSpaceSubscription()
+			local _, setState = useState(0)
+			subs:add(setState)
+		end
+
+		local triggerHookTransition
+		local Component
+		Component = function(props)
+			useUserSpaceSubscription()
+			if props.level == 0 then
+				local _, start = useTransition()
+				triggerHookTransition = start
+			end
+			if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
+				return React.createElement(Component, { level = props.level + 1 })
+			end
+			return nil
+		end
+
+		act(function()
+			ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+				unstable_isConcurrent = true,
+			})
+		end)
+
+		local warning = "Detected a large number of updates inside startTransition. "
+			.. "If this is due to a subscription please re-write it to use React provided hooks. "
+			.. "Otherwise concurrent mode guarantees are off the table."
+
+		jestExpect(function()
+			act(function()
+				React.startTransition(function()
+					subs:forEach(function(setState)
+						setState(function(state)
+							return state + 1
+						end)
+					end)
+				end)
+			end)
+		end).toWarnDev({ warning }, { withoutStack = true })
+
+		jestExpect(function()
+			act(function()
+				triggerHookTransition(function()
+					subs:forEach(function(setState)
+						setState(function(state)
+							return state + 1
+						end)
+					end)
+				end)
+			end)
+		end).toWarnDev({ warning }, { withoutStack = true })
+	end)
+end)

--- a/modules/react/src/__tests__/ReactStartTransition.spec.lua
+++ b/modules/react/src/__tests__/ReactStartTransition.spec.lua
@@ -39,59 +39,95 @@ describe("ReactStartTransition", function()
 		useTransition = React.useTransition
 	end)
 
-	it("Warns if a suspicious number of fibers are updated inside startTransition", function()
-		local subs = Set.new()
-		local function useUserSpaceSubscription()
-			local _, setState = useState(0)
-			subs:add(setState)
+	it(
+		"Warns if a suspicious number of fibers are updated inside startTransition",
+		function()
+			local subs = Set.new()
+			local function useUserSpaceSubscription()
+				local _, setState = useState(0)
+				subs:add(setState)
+			end
+
+			local triggerHookTransition
+			local Component
+			Component = function(props)
+				useUserSpaceSubscription()
+				if props.level == 0 then
+					local _, start = useTransition()
+					triggerHookTransition = start
+				end
+				if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
+					return React.createElement(Component, { level = props.level + 1 })
+				end
+				return nil
+			end
+
+			act(function()
+				ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+					unstable_isConcurrent = true,
+				})
+			end)
+
+			local warning = "Detected a large number of updates inside startTransition. "
+				.. "If this is due to a subscription please re-write it to use React provided hooks. "
+				.. "Otherwise concurrent mode guarantees are off the table."
+
+			jestExpect(function()
+				act(function()
+					React.startTransition(function()
+						subs:forEach(function(setState)
+							setState(function(state)
+								return state + 1
+							end)
+						end)
+					end)
+				end)
+			end).toWarnDev({ warning }, { withoutStack = true })
+
+			jestExpect(function()
+				act(function()
+					triggerHookTransition(function()
+						subs:forEach(function(setState)
+							setState(function(state)
+								return state + 1
+							end)
+						end)
+					end)
+				end)
+			end).toWarnDev({ warning }, { withoutStack = true })
 		end
+	)
+
+	it("preserves errors thrown by transition callbacks", function()
+		local globalSucceeded, globalError = pcall(function()
+			React.startTransition(function()
+				error("global transition failure", 0)
+			end)
+		end)
+		jestExpect(globalSucceeded).toBe(false)
+		jestExpect(globalError).toBe("global transition failure")
 
 		local triggerHookTransition
-		local Component
-		Component = function(props)
-			useUserSpaceSubscription()
-			if props.level == 0 then
-				local _, start = useTransition()
-				triggerHookTransition = start
-			end
-			if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
-				return React.createElement(Component, { level = props.level + 1 })
-			end
+		local function Component()
+			local _, start = useTransition()
+			triggerHookTransition = start
 			return nil
 		end
 
 		act(function()
-			ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+			ReactTestRenderer.create(React.createElement(Component), {
 				unstable_isConcurrent = true,
 			})
 		end)
 
-		local warning = "Detected a large number of updates inside startTransition. "
-			.. "If this is due to a subscription please re-write it to use React provided hooks. "
-			.. "Otherwise concurrent mode guarantees are off the table."
-
-		jestExpect(function()
-			act(function()
-				React.startTransition(function()
-					subs:forEach(function(setState)
-						setState(function(state)
-							return state + 1
-						end)
-					end)
-				end)
-			end)
-		end).toWarnDev({ warning }, { withoutStack = true })
-
-		jestExpect(function()
+		local hookSucceeded, hookError = pcall(function()
 			act(function()
 				triggerHookTransition(function()
-					subs:forEach(function(setState)
-						setState(function(state)
-							return state + 1
-						end)
-					end)
+					error("hook transition failure", 0)
 				end)
 			end)
-		end).toWarnDev({ warning }, { withoutStack = true })
+		end)
+		jestExpect(hookSucceeded).toBe(false)
+		jestExpect(hookError).toBe("hook transition failure")
 	end)
 end)

--- a/modules/shared/src/ReactFeatureFlags.lua
+++ b/modules/shared/src/ReactFeatureFlags.lua
@@ -155,4 +155,8 @@ exports.enableEagerRootListeners = false
 
 exports.enableDoubleInvokingEffects = false
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/shared/forks/ReactFeatureFlags.www.js
+-- ROBLOX deviation: Transition tracing is not available in React Lua.
+exports.enableTransitionTracing = false
+
 return exports

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
@@ -13,7 +13,14 @@
  * Keeps track of the current batch's configuration such as how long an update
  * should suspend for if it needs to.
 ]]
-local ReactCurrentBatchConfig = {
+local ReactTypes = require(script.Parent.Parent.ReactTypes)
+type BatchConfigTransition = ReactTypes.BatchConfigTransition
+
+type BatchConfig = {
+	transition: BatchConfigTransition?,
+}
+
+local ReactCurrentBatchConfig: BatchConfig = {
 	transition = nil,
 }
 

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
@@ -1,5 +1,5 @@
 --!strict
--- ROBLOX upstream: https://github.com/facebook/react/blob/92fcd46cc79bbf45df4ce86b0678dcef3b91078d/packages/react/src/ReactCurrentBatchConfig.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactCurrentBatchConfig.js
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -14,7 +14,7 @@
  * should suspend for if it needs to.
 ]]
 local ReactCurrentBatchConfig = {
-	transition = 0,
+	transition = nil,
 }
 
 return ReactCurrentBatchConfig

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -39,6 +39,10 @@ type MutableSourceGetSnapshotFn<Source, Snapshot> = ReactTypes.MutableSourceGetS
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 export type Dispatcher = {
 	readContext: <T>(
@@ -77,9 +81,9 @@ export type Dispatcher = {
 		deps: Array<any> | nil
 	) -> (),
 	useDebugValue: <T>(value: T, formatterFn: ((value: T) -> any)?) -> (),
-	-- ROBLOX TODO: make these non-optional and implement them in the dispatchers
-	useDeferredValue: (<T>(value: T) -> T)?,
-	useTransition: (() -> ((() -> ()) -> (), boolean))?, -- ROBLOX deviation: Luau doesn't support jagged array types [(() -> ()) -> (), boolean],
+	useDeferredValue: <T>(value: T) -> T,
+	-- ROBLOX deviation: Luau represents React's tuple as multiple return values.
+	useTransition: () -> (boolean, StartTransition),
 	useMutableSource: <Source, Snapshot>(
 		source: MutableSource<Source>,
 		getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -39,10 +39,7 @@ type MutableSourceGetSnapshotFn<Source, Snapshot> = ReactTypes.MutableSourceGetS
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 
 export type Dispatcher = {
 	readContext: <T>(

--- a/modules/shared/src/ReactTypes.lua
+++ b/modules/shared/src/ReactTypes.lua
@@ -21,6 +21,21 @@ type React_Node = flowtypes.React_Node
 type SimpleMap<K, V> = { [K]: V }
 type Iterable<T> = SimpleMap<string | number, T> | Array<T>
 
+export type BatchConfigTransition = {
+	_updatedFibers: any?,
+	name: string?,
+	startTime: number?,
+}
+
+export type StartTransitionOptions = {
+	name: string?,
+}
+
+export type StartTransition = (
+	callback: () -> (),
+	options: StartTransitionOptions?
+) -> ()
+
 export type ReactNode<T = any> =
 	React_Element<T>
 	| ReactPortal

--- a/modules/shared/src/init.lua
+++ b/modules/shared/src/init.lua
@@ -29,6 +29,9 @@ local ErrorHandling = require(script["ErrorHandling.roblox"])
 
 -- Re-export all top-level public types
 export type ReactEmpty = ReactTypes.ReactEmpty
+export type BatchConfigTransition = ReactTypes.BatchConfigTransition
+export type StartTransitionOptions = ReactTypes.StartTransitionOptions
+export type StartTransition = ReactTypes.StartTransition
 export type ReactFragment = ReactTypes.ReactFragment
 export type ReactNodeList = ReactTypes.ReactNodeList
 export type ReactProviderType<T> = ReactTypes.ReactProviderType<T>


### PR DESCRIPTION
## Summary

Backport the stable React 18 `startTransition`, `useTransition`, and `useDeferredValue` APIs to React-Luau. Add native transition lane allocation and update-queue entanglement for hooks and class updates, plus transition-aware debug inspection. Port the applicable upstream React 18 and 18.1 coverage while leaving cache APIs, transition tracing, and React 19 async Actions out of scope.

Generated with Codex.