### PR TITLE
feat(react): backport React 19 ref as prop

### DIFF
--- a/modules/react-reconciler/src/ReactChildFiber.new.lua
+++ b/modules/react-reconciler/src/ReactChildFiber.new.lua
@@ -12,7 +12,6 @@ local Packages = script.Parent.Parent
 local ReactGlobals = require(Packages.ReactGlobals)
 local LuauPolyfill = require(Packages.LuauPolyfill)
 local Array = LuauPolyfill.Array
-local Error = LuauPolyfill.Error
 type Array<T> = { [number]: T }
 type Set<T> = { [T]: boolean }
 type Object = { [any]: any }
@@ -147,156 +146,12 @@ end
 
 local isArray = Array.isArray
 
-function coerceRef(returnFiber: Fiber, current: Fiber | nil, element: ReactElement)
-	local mixedRef = element.ref
-	if mixedRef ~= nil and type(mixedRef) == "string" then
-		-- ROBLOX deviation: we do not support string refs, and will not coerce
-		if
-			not element._owner
-			or not element._self
-			or element._owner.stateNode == element._self
-		then
-			-- ROBLOX performance: don't get component name unless we have to use it
-			local componentName
-			if __DEV__ then
-				componentName = getComponentName(returnFiber.type) or "Component"
-			else
-				componentName = "<enable __DEV__ mode for component names>"
-			end
-			error(
-				Error.new(
-					string.format(
-						'Component "%s" contains the string ref "%s". Support for string refs '
-							-- ROBLOX deviation: we removed string ref support ahead of upstream schedule
-							.. "has been removed. We recommend using "
-							.. "useRef() or createRef() instead. "
-							.. "Learn more about using refs safely here: "
-							.. "https://reactjs.org/link/strict-mode-string-ref",
-						componentName,
-						tostring(mixedRef)
-					)
-				)
-			)
-		end
-
-		if not element._owner then
-			error(
-				"Expected ref to be a function or an object returned by React.createRef(), or nil."
-			)
-		end
-
-		-- if __DEV__ then
-		-- 	-- TODO: Clean this up once we turn on the string ref warning for
-		-- 	-- everyone, because the strict mode case will no longer be relevant
-		-- 	if
-		-- 		(bit32.band(returnFiber.mode, StrictMode) ~= 0 or warnAboutStringRefs)
-		-- 		-- We warn in ReactElement.js if owner and self are equal for string refs
-		-- 		-- because these cannot be automatically converted to an arrow function
-		-- 		-- using a codemod. Therefore, we don't have to warn about string refs again.
-		-- 		and not (
-		-- 			element._owner
-		-- 			and element._self
-		-- 			and element._owner.stateNode ~= element._self
-		-- 		)
-		-- 	then
-		-- 		local componentName = getComponentName(returnFiber.type) or "Component"
-		-- 		if not didWarnAboutStringRefs[componentName] then
-		-- 			if warnAboutStringRefs then
-		-- 				console.error(
-		-- 					'Component "%s" contains the string ref "%s". Support for string refs '
-		-- 						.. "will be removed in a future major release. We recommend using "
-		-- 						.. "useRef() or createRef() instead. "
-		-- 						.. "Learn more about using refs safely here: "
-		-- 						.. "https://reactjs.org/link/strict-mode-string-ref",
-		-- 					componentName,
-		-- 					mixedRef
-		-- 				)
-		-- 			else
-		-- 				console.error(
-		-- 					'A string ref, "%s", has been found within a strict mode tree. '
-		-- 						.. "String refs are a source of potential bugs and should be avoided. "
-		-- 						.. "We recommend using useRef() or createRef() instead. "
-		-- 						.. "Learn more about using refs safely here: "
-		-- 						.. "https://reactjs.org/link/strict-mode-string-ref",
-		-- 					mixedRef
-		-- 				)
-		-- 			end
-		-- 			didWarnAboutStringRefs[componentName] = true
-		-- 		end
-		-- 	end
-		-- end
-
-		-- if element._owner then
-		-- 	local owner: Fiber? = element._owner
-		-- 	local inst
-		-- 	if owner then
-		-- 		local ownerFiber = owner
-		-- 		invariant(
-		-- 			ownerFiber.tag == ClassComponent,
-		-- 			"Function components cannot have string refs. "
-		-- 				.. "We recommend using useRef() instead. "
-		-- 				.. "Learn more about using refs safely here: "
-		-- 				.. "https://reactjs.org/link/strict-mode-string-ref"
-		-- 		)
-		-- 		inst = ownerFiber.stateNode
-		-- 	end
-		-- 	invariant(
-		-- 		inst,
-		-- 		"Missing owner for string ref %s. This error is likely caused by a "
-		-- 			.. "bug in React. Please file an issue.",
-		-- 		mixedRef
-		-- 	)
-
-		-- 	-- ROBLOX deviation: explicitly convert to string
-		-- 	local stringRef = tostring(mixedRef)
-		-- 	-- Check if previous string ref matches new string ref
-		-- 	if
-		-- 		current ~= nil
-		-- 		and (current :: Fiber).ref ~= nil
-		-- 		-- ROBLOX deviation: Lua doesn't support fields on functions, so invert this check
-		-- 		-- typeof((current :: Fiber).ref) == 'function' and
-		-- 		and typeof((current :: Fiber).ref) ~= "function"
-		-- 		-- ROBLOX deviation: this partially inlines the ref type from Fiber to workaround Luau refinement issues
-		-- 		and ((current :: Fiber).ref :: { _stringRef: string? })._stringRef
-		-- 			== stringRef
-		-- 	then
-		-- 		return (current :: Fiber).ref
-		-- 	end
-		-- 	-- ROBLOX deviation: make ref a callable table rather than a function
-		-- 	local callableRef = function(value)
-		-- 		local refs = inst.__refs
-		-- 		if refs == emptyRefsObject then
-		-- 			-- This is a lazy pooled frozen object, so we need to initialize.
-		-- 			inst.__refs = {}
-		-- 			refs = inst.__refs
-		-- 		end
-		-- 		if value == nil then
-		-- 			refs[stringRef] = nil
-		-- 		else
-		-- 			refs[stringRef] = value
-		-- 		end
-		-- 	end
-		-- 	local ref = setmetatable({}, { __call = callableRef })
-		-- 	ref._stringRef = stringRef
-		-- 	return ref
-		-- else
-		-- 	invariant(
-		-- 		typeof(mixedRef) == "string",
-		-- 		"Expected ref to be a function, a string, an object returned by React.createRef(), or nil."
-		-- 	)
-		-- 	invariant(
-		-- 		element._owner,
-		-- 		"Element ref was specified as a string (%s) but no owner was set. This could happen for one of"
-		-- 			.. " the following reasons:\n"
-		-- 			.. "1. You may be adding a ref to a function component\n"
-		-- 			.. "2. You may be adding a ref to a component that was not created inside a component's render method\n"
-		-- 			.. "3. You have multiple copies of React loaded\n"
-		-- 			.. "See https://reactjs.org/link/refs-must-have-owner for more information.",
-		-- 		mixedRef
-		-- 	)
-		-- end
-	end
-	return mixedRef
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactChildFiber.js#L253-L262
+function coerceRef(_returnFiber: Fiber, _current: Fiber | nil, element: ReactElement)
+	-- TODO: This is a temporary, intermediate step. Now that enableRefAsProp is on,
+	-- we should resolve the `ref` prop during the begin phase of the component
+	-- it's attached to (HostComponent, ClassComponent, etc).
+	return element.props.ref
 end
 
 -- ROBLOX performance: all uses commented out

--- a/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
@@ -397,6 +397,26 @@ local function updateForwardRef(
 	local render = Component.render
 	local ref = workInProgress.ref
 
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L397-L422
+	local propsWithoutRef
+	-- ROBLOX DEVIATION: A Luau table cannot contain a key whose value is nil, so
+	-- checking the value is equivalent to JavaScript's `in` check here.
+	-- ROBLOX DEVIATION: Access through the existing module table to avoid another
+	-- local in a file that is at Luau's local register limit.
+	if ReactFeatureFlags.enableRefAsProp and nextProps.ref ~= nil then
+		-- `ref` is just a prop now, but `forwardRef` expects it to not appear in
+		-- the props object. This used to happen in the JSX runtime, but now we do
+		-- it here.
+		propsWithoutRef = {}
+		for key, value in nextProps do
+			if key ~= "ref" then
+				propsWithoutRef[key] = value
+			end
+		end
+	else
+		propsWithoutRef = nextProps
+	end
+
 	-- The rest is a fork of updateFunctionComponent
 	local nextChildren
 	prepareToReadContext(
@@ -407,8 +427,14 @@ local function updateForwardRef(
 	if __DEV__ then
 		ReactCurrentOwner.current = workInProgress
 		setIsRendering(true)
-		nextChildren =
-			renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes)
+		nextChildren = renderWithHooks(
+			current,
+			workInProgress,
+			render,
+			propsWithoutRef,
+			ref,
+			renderLanes
+		)
 		if
 			debugRenderPhaseSideEffectsForStrictMode
 			and bit32.band(workInProgress.mode, StrictMode) ~= 0
@@ -420,7 +446,7 @@ local function updateForwardRef(
 				current,
 				workInProgress,
 				render,
-				nextProps,
+				propsWithoutRef,
 				ref,
 				renderLanes
 			)
@@ -436,8 +462,14 @@ local function updateForwardRef(
 		end
 		setIsRendering(false)
 	else
-		nextChildren =
-			renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes)
+		nextChildren = renderWithHooks(
+			current,
+			workInProgress,
+			render,
+			propsWithoutRef,
+			ref,
+			renderLanes
+		)
 	end
 
 	if current ~= nil and not didReceiveUpdate then
@@ -803,13 +835,24 @@ function updateProfiler(current: Fiber | nil, workInProgress: Fiber, renderLanes
 end
 
 local function markRef(current: Fiber | nil, workInProgress: Fiber)
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L1039-L1058
+	-- ROBLOX DEVIATION: This React 17 fork does not have the RefStatic flag.
 	local ref = workInProgress.ref
-	if
-		(current == nil and ref ~= nil)
-		or (current ~= nil and (current :: Fiber).ref ~= ref)
-	then
-		-- Schedule a Ref effect
-		workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+	if ref == nil then
+		if current ~= nil and (current :: Fiber).ref ~= nil then
+			-- Schedule a Ref effect
+			workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+		end
+	else
+		if type(ref) ~= "function" and type(ref) ~= "table" then
+			error(
+				"Expected ref to be a function, an object returned by React.createRef(), or undefined/null."
+			)
+		end
+		if current == nil or (current :: Fiber).ref ~= ref then
+			-- Schedule a Ref effect
+			workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+		end
 	end
 end
 
@@ -1357,7 +1400,12 @@ local function mountLazyComponent(
 	workInProgress.type = Component
 	workInProgress.tag = resolveLazyComponentTag(Component)
 	local resolvedTag = workInProgress.tag
-	local resolvedProps = resolveDefaultProps(Component, props)
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L1677-L1727
+	-- ROBLOX DEVIATION: Access through the existing module table to avoid another
+	-- local in a file that is at Luau's local register limit.
+	local resolvedProps = if resolvedTag == ClassComponent
+		then ReactFiberClassComponent.resolveClassComponentProps(Component, props, false)
+		else resolveDefaultProps(Component, props)
 	local child
 	if resolvedTag == FunctionComponent then
 		if __DEV__ then
@@ -1741,7 +1789,7 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any)
 		--     )
 		--   end
 		-- end
-		if workInProgress.ref ~= nil then
+		if not ReactFeatureFlags.enableRefAsProp and workInProgress.ref ~= nil then
 			local info = ""
 			local ownerName = getCurrentFiberOwnerNameInDevOrNull()
 			if ownerName then
@@ -3516,8 +3564,12 @@ local function beginWork(current: any, workInProgress: Fiber, renderLanes: Lanes
 	elseif workInProgress.tag == ClassComponent then
 		local Component = workInProgress.type
 		local unresolvedProps = workInProgress.pendingProps
-		local resolvedProps = workInProgress.elementType == Component and unresolvedProps
-			or resolveDefaultProps(Component, unresolvedProps)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L3738-L3752
+		local resolvedProps = ReactFiberClassComponent.resolveClassComponentProps(
+			Component,
+			unresolvedProps,
+			workInProgress.elementType == Component
+		)
 		return updateClassComponent(
 			current,
 			workInProgress,
@@ -3600,8 +3652,12 @@ local function beginWork(current: any, workInProgress: Fiber, renderLanes: Lanes
 	elseif workInProgress.tag == IncompleteClassComponent then
 		local Component = workInProgress.type
 		local unresolvedProps = workInProgress.pendingProps
-		local resolvedProps = workInProgress.elementType == Component and unresolvedProps
-			or resolveDefaultProps(Component, unresolvedProps)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L3827-L3844
+		local resolvedProps = ReactFiberClassComponent.resolveClassComponentProps(
+			Component,
+			unresolvedProps,
+			workInProgress.elementType == Component
+		)
 		return mountIncompleteClassComponent(
 			current,
 			workInProgress,

--- a/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
+++ b/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
@@ -43,6 +43,7 @@ local enableDebugTracing = ReactFeatureFlags.enableDebugTracing
 local enableSchedulingProfiler = ReactFeatureFlags.enableSchedulingProfiler
 local warnAboutDeprecatedLifecycles = ReactFeatureFlags.warnAboutDeprecatedLifecycles
 local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffects
+local enableRefAsProp = ReactFeatureFlags.enableRefAsProp
 
 local ReactStrictModeWarnings = require(script.Parent["ReactStrictModeWarnings.new"])
 local isMounted = require(script.Parent.ReactFiberTreeReflection).isMounted
@@ -58,8 +59,7 @@ local ReactSymbols = require(Packages.Shared).ReactSymbols
 local REACT_CONTEXT_TYPE = ReactSymbols.REACT_CONTEXT_TYPE
 local REACT_PROVIDER_TYPE = ReactSymbols.REACT_PROVIDER_TYPE
 
-local resolveDefaultProps =
-	require(script.Parent["ReactFiberLazyComponent.new"]).resolveDefaultProps
+local resolveClassComponentProps
 local ReactTypeOfMode = require(script.Parent.ReactTypeOfMode)
 local DebugTracingMode = ReactTypeOfMode.DebugTracingMode
 local StrictMode = ReactTypeOfMode.StrictMode
@@ -110,10 +110,6 @@ local fakeInternalInstance = {}
 
 -- React.Component uses a shared frozen object by default.
 -- We'll use it to determine whether we need to initialize legacy refs.
--- ROBLOX deviation: Uses __refs instead of refs to avoid conflicts
--- local emptyRefsObject = React.Component:extend("").refs
-local emptyRefsObject = React.Component:extend("").__refs
-
 local didWarnAboutStateAssignmentForComponent
 local didWarnAboutUninitializedState
 local didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate
@@ -958,9 +954,9 @@ local function mountClassInstance(
 	local instance = workInProgress.stateNode
 	instance.props = newProps
 	instance.state = workInProgress.memoizedState
-	-- ROBLOX deviation: Uses __refs instead of refs to avoid conflicts
-	-- instance.refs = emptyRefsObject
-	instance.__refs = emptyRefsObject
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberClassComponent.js#L768-L783
+	-- ROBLOX DEVIATION: React-Luau uses __refs instead of refs to avoid conflicts.
+	instance.__refs = {}
 
 	initializeUpdateQueue(workInProgress)
 
@@ -1064,8 +1060,16 @@ function resumeMountClassInstance(
 ): boolean
 	local instance = workInProgress.stateNode
 
-	local oldProps = workInProgress.memoizedProps
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/bc1fac0e9da23990469d328e330aafdd364759b8/packages/react-reconciler/src/ReactFiberClassComponent.js#L904-L938
+	local unresolvedOldProps = workInProgress.memoizedProps
+	local oldProps = resolveClassComponentProps(
+		ctor,
+		unresolvedOldProps,
+		workInProgress.type == workInProgress.elementType
+	)
 	instance.props = oldProps
+	local unresolvedNewProps = workInProgress.pendingProps
+	local didReceiveNewProps = unresolvedNewProps ~= unresolvedOldProps
 
 	local oldContext = instance.context
 	local contextType = ctor.contextType
@@ -1096,7 +1100,7 @@ function resumeMountClassInstance(
 			or type(instance.componentWillReceiveProps) == "function"
 		)
 	then
-		if oldProps ~= newProps or oldContext ~= nextContext then
+		if didReceiveNewProps or oldContext ~= nextContext then
 			callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext)
 		end
 	end
@@ -1109,7 +1113,7 @@ function resumeMountClassInstance(
 	processUpdateQueue(workInProgress, newProps, instance, renderLanes)
 	newState = workInProgress.memoizedState
 	if
-		oldProps == newProps
+		not didReceiveNewProps
 		and oldState == newState
 		and not hasContextChanged()
 		and not checkHasForceUpdateAfterProcessing()
@@ -1216,9 +1220,11 @@ local function updateClassInstance(
 	cloneUpdateQueue(current, workInProgress)
 
 	local unresolvedOldProps = workInProgress.memoizedProps
-	local oldProps = if workInProgress.type == workInProgress.elementType
-		then unresolvedOldProps
-		else resolveDefaultProps(workInProgress.type, unresolvedOldProps)
+	local oldProps = resolveClassComponentProps(
+		ctor,
+		unresolvedOldProps,
+		workInProgress.type == workInProgress.elementType
+	)
 	instance.props = oldProps
 	local unresolvedNewProps = workInProgress.pendingProps
 
@@ -1420,14 +1426,45 @@ local function updateClassInstance(
 	return shouldUpdate
 end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/8a13ea0b7a4b161add410779e0abe2cd4cc230d2/packages/react-reconciler/src/ReactFiberClassComponent.js#L1229-L1265
+resolveClassComponentProps = function(
+	Component: any,
+	baseProps: { [any]: any },
+	alreadyResolvedDefaultProps: boolean
+): { [any]: any }
+	local newProps = baseProps
+	-- Resolve default props. Taken from old JSX runtime, where this used to live.
+	local defaultProps = Component.defaultProps
+	if defaultProps and not alreadyResolvedDefaultProps then
+		newProps = Object.assign({}, newProps, baseProps)
+		for propName, value in defaultProps do
+			if newProps[propName] == nil then
+				newProps[propName] = value
+			end
+		end
+	end
+
+	if enableRefAsProp then
+		-- Remove ref from the props object, if it exists.
+		-- ROBLOX DEVIATION: A Luau table cannot contain a key whose value is nil, so
+		-- checking the value is equivalent to JavaScript's `in` check here.
+		if newProps.ref ~= nil then
+			if newProps == baseProps then
+				newProps = Object.assign({}, newProps)
+			end
+			newProps.ref = nil
+		end
+	end
+	return newProps
+end
+
 return {
 	adoptClassInstance = adoptClassInstance,
 	constructClassInstance = constructClassInstance,
 	mountClassInstance = mountClassInstance,
 	resumeMountClassInstance = resumeMountClassInstance,
 	updateClassInstance = updateClassInstance,
+	resolveClassComponentProps = resolveClassComponentProps,
 
 	applyDerivedStateFromProps = applyDerivedStateFromProps,
-	-- deviation: this should be safe to export, since it gets assigned only once
-	emptyRefsObject = emptyRefsObject,
 }

--- a/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
@@ -151,8 +151,9 @@ local resetCurrentDebugFiberInDEV = ReactCurrentFiber.resetCurrentFiber
 local setCurrentDebugFiberInDEV = ReactCurrentFiber.setCurrentFiber
 local onCommitUnmount =
 	require(script.Parent["ReactFiberDevToolsHook.new"]).onCommitUnmount
-local resolveDefaultProps =
-	require(script.Parent["ReactFiberLazyComponent.new"]).resolveDefaultProps
+-- ROBLOX upstream: https://github.com/facebook/react/blob/6121c95baf590e6c4ab0ea697f4f4a07e1d898f0/packages/react-reconciler/src/ReactFiberCommitWork.js#L104-L107
+local resolveClassComponentProps =
+	require(script.Parent["ReactFiberClassComponent.new"]).resolveClassComponentProps
 local ReactProfilerTimer = require(script.Parent["ReactProfilerTimer.new"])
 local startLayoutEffectTimer = ReactProfilerTimer.startLayoutEffectTimer
 local recordPassiveEffectDuration = ReactProfilerTimer.recordPassiveEffectDuration
@@ -260,7 +261,12 @@ local nearestProfilerOnStack: Fiber | nil = nil
 -- local PossiblyWeakSet = typeof WeakSet == 'function' ? WeakSet : Set
 
 local function callComponentWillUnmountWithTimer(current, instance)
-	instance.props = current.memoizedProps
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/bc1fac0e9da23990469d328e330aafdd364759b8/packages/react-reconciler/src/ReactFiberCommitWork.js#L244-L252
+	instance.props = resolveClassComponentProps(
+		current.type,
+		current.memoizedProps,
+		current.elementType == current.type
+	)
 	instance.state = current.memoizedState
 	if
 		enableProfilerTimer
@@ -349,8 +355,13 @@ local function commitBeforeMutationLifeCycles(
 				-- but instead we rely on them being set during last render.
 				-- TODO: revisit this when we implement resuming.
 				if __DEV__ then
+					-- ROBLOX upstream: https://github.com/facebook/react/blob/8a13ea0b7a4b161add410779e0abe2cd4cc230d2/packages/react-reconciler/src/ReactFiberCommitWork.js#L472-L481
+					-- ROBLOX DEVIATION: Luau cannot distinguish an absent `ref` key from
+					-- one set to nil. The same value check is used in the lifecycle and
+					-- callback warning guards below.
 					if
-						finishedWork.type == finishedWork.elementType
+						not finishedWork.type.defaultProps
+						and finishedWork.memoizedProps.ref == nil
 						and not didWarnAboutReassigningProps
 					then
 						if instance.props ~= finishedWork.memoizedProps then
@@ -377,8 +388,11 @@ local function commitBeforeMutationLifeCycles(
 				end
 				-- deviation: Call with ':' instead of '.' so that self is available
 				local snapshot = instance:getSnapshotBeforeUpdate(
-					finishedWork.elementType == finishedWork.type and prevProps
-						or resolveDefaultProps(finishedWork.type, prevProps),
+					resolveClassComponentProps(
+						finishedWork.type,
+						prevProps,
+						finishedWork.elementType == finishedWork.type
+					),
 					prevState
 				)
 				if __DEV__ then
@@ -887,7 +901,8 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 			-- TODO: revisit this when we implement resuming.
 			if __DEV__ then
 				if
-					finishedWork.type == finishedWork.elementType
+					not finishedWork.type.defaultProps
+					and finishedWork.memoizedProps.ref == nil
 					and not didWarnAboutReassigningProps
 				then
 					if instance.props ~= finishedWork.memoizedProps then
@@ -932,16 +947,19 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 				instance:componentDidMount()
 			end
 		else
-			local prevProps = finishedWork.elementType == finishedWork.type
-					and current.memoizedProps
-				or resolveDefaultProps(finishedWork.type, current.memoizedProps)
+			local prevProps = resolveClassComponentProps(
+				finishedWork.type,
+				current.memoizedProps,
+				finishedWork.elementType == finishedWork.type
+			)
 			local prevState = current.memoizedState
 			-- We could update instance props and state here,
 			-- but instead we rely on them being set during last render.
 			-- TODO: revisit this when we implement resuming.
 			if __DEV__ then
 				if
-					finishedWork.type == finishedWork.elementType
+					not finishedWork.type.defaultProps
+					and finishedWork.memoizedProps.ref == nil
 					and not didWarnAboutReassigningProps
 				then
 					if instance.props ~= finishedWork.memoizedProps then
@@ -1002,7 +1020,8 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 	if updateQueue ~= nil then
 		if __DEV__ then
 			if
-				finishedWork.type == finishedWork.elementType
+				not finishedWork.type.defaultProps
+				and finishedWork.memoizedProps.ref == nil
 				and not didWarnAboutReassigningProps
 			then
 				if instance.props ~= finishedWork.memoizedProps then

--- a/modules/react-reconciler/src/__tests__/ReactClassComponentPropResolution.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactClassComponentPropResolution.spec.lua
@@ -1,0 +1,151 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/__tests__/ReactClassComponentPropResolution-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ ]]
+--!strict
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+local it = JestGlobals.it
+
+local React
+local ReactNoop
+local Scheduler
+local Object
+
+-- ROBLOX DEVIATION: React-Luau records Scheduler logs with
+-- unstable_yieldValue/toHaveYielded, and ReactNoop.act is synchronous.
+describe("ReactClassComponentPropResolution", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Dev.Scheduler)
+		Object = require(Packages.LuauPolyfill).Object
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	it("resolves ref and default props before calling lifecycle methods", function()
+		local root = ReactNoop.createRoot()
+		local function getPropKeys(props)
+			local keys = Object.keys(props)
+			-- ROBLOX DEVIATION: Luau table iteration order is unspecified.
+			table.sort(keys)
+			return table.concat(keys, ", ")
+		end
+
+		local Component = React.Component:extend("Component")
+		-- ROBLOX DEVIATION: React-Luau class constructors are init methods and
+		-- receive their props through self.props.
+		function Component:init()
+			Scheduler.unstable_yieldValue("constructor: " .. getPropKeys(self.props))
+		end
+		function Component:shouldComponentUpdate(props)
+			Scheduler.unstable_yieldValue(
+				"shouldComponentUpdate (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"shouldComponentUpdate (next props): " .. getPropKeys(props)
+			)
+			return true
+		end
+		function Component:componentDidUpdate(props)
+			Scheduler.unstable_yieldValue(
+				"componentDidUpdate (prev props): " .. getPropKeys(props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentDidUpdate (next props): " .. getPropKeys(self.props)
+			)
+			return true
+		end
+		function Component:componentDidMount()
+			Scheduler.unstable_yieldValue(
+				"componentDidMount: " .. getPropKeys(self.props)
+			)
+			return true
+		end
+		function Component:UNSAFE_componentWillMount()
+			Scheduler.unstable_yieldValue(
+				"componentWillMount: " .. getPropKeys(self.props)
+			)
+		end
+		function Component:UNSAFE_componentWillReceiveProps(nextProps)
+			Scheduler.unstable_yieldValue(
+				"componentWillReceiveProps (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentWillReceiveProps (next props): " .. getPropKeys(nextProps)
+			)
+		end
+		function Component:UNSAFE_componentWillUpdate(nextProps)
+			Scheduler.unstable_yieldValue(
+				"componentWillUpdate (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentWillUpdate (next props): " .. getPropKeys(nextProps)
+			)
+		end
+		function Component:componentWillUnmount()
+			Scheduler.unstable_yieldValue(
+				"componentWillUnmount: " .. getPropKeys(self.props)
+			)
+		end
+		function Component:render()
+			return React.createElement(Text, {
+				text = "render: " .. getPropKeys(self.props),
+			})
+		end
+		Component.defaultProps = {
+			default = "yo",
+		}
+
+		-- `ref` should never appear as a prop. `default` always should.
+
+		-- Mount
+		local ref = React.createRef()
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { text = "Yay", ref = ref }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"constructor: default, text",
+			"componentWillMount: default, text",
+			"render: default, text",
+			"componentDidMount: default, text",
+		})
+		-- Update
+		ReactNoop.act(function()
+			root.render(
+				React.createElement(Component, { text = "Yay (again)", ref = ref })
+			)
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"componentWillReceiveProps (prev props): default, text",
+			"componentWillReceiveProps (next props): default, text",
+			"shouldComponentUpdate (prev props): default, text",
+			"shouldComponentUpdate (next props): default, text",
+			"componentWillUpdate (prev props): default, text",
+			"componentWillUpdate (next props): default, text",
+			"render: default, text",
+			"componentDidUpdate (prev props): default, text",
+			"componentDidUpdate (next props): default, text",
+		})
+		-- Unmount
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "componentWillUnmount: default, text" })
+	end)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactFiberRefs.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactFiberRefs.spec.lua
@@ -1,0 +1,183 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/__tests__/ReactFiberRefs-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ ]]
+--!strict
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+local it = JestGlobals.it
+local Set = require(Packages.LuauPolyfill).Set
+
+local React
+local ReactNoop
+local Scheduler
+
+-- ROBLOX DEVIATION: React-Luau records Scheduler logs with
+-- unstable_yieldValue/toHaveYielded, and ReactNoop.act is synchronous.
+describe("ReactFiberRefs", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Dev.Scheduler)
+	end)
+
+	it("ref is attached even if there are no other updates (class)", function()
+		local component
+		local Component = React.Component:extend("Component")
+		function Component:shouldComponentUpdate()
+			-- This component's output doesn't depend on any props or state
+			return false
+		end
+		function Component:render()
+			Scheduler.unstable_yieldValue("Render")
+			component = self
+			return "Hi"
+		end
+
+		local ref1 = React.createRef()
+		local ref2 = React.createRef()
+		local root = ReactNoop.createRoot()
+
+		-- Mount with ref1 attached
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { ref = ref1 }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "Render" })
+		jestExpect(root).toMatchRenderedOutput("Hi")
+		jestExpect(ref1.current).toBe(component)
+		-- ref2 has no value
+		jestExpect(ref2.current).toBe(nil)
+
+		-- Switch to ref2, but don't update anything else.
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { ref = ref2 }))
+		end)
+		-- The component did not re-render because no props changed.
+		jestExpect(Scheduler).toHaveYielded({})
+		jestExpect(root).toMatchRenderedOutput("Hi")
+		-- But the refs still should have been swapped.
+		jestExpect(ref1.current).toBe(nil)
+		jestExpect(ref2.current).toBe(component)
+	end)
+
+	it("ref is attached even if there are no other updates (host component)", function()
+		-- This is kind of a silly test because host components never bail out if they
+		-- receive a new element, and there's no way to update a ref without also
+		-- updating the props, but adding it here anyway for symmetry with the
+		-- class case above.
+		local ref1 = React.createRef()
+		local ref2 = React.createRef()
+		local root = ReactNoop.createRoot()
+
+		-- Mount with ref1 attached
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = ref1 }, "Hi"))
+		end)
+		jestExpect(root).toMatchRenderedOutput(React.createElement("div", nil, "Hi"))
+		jestExpect(ref1.current).never.toBe(nil)
+		-- ref2 has no value
+		jestExpect(ref2.current).toBe(nil)
+
+		-- Switch to ref2, but don't update anything else.
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = ref2 }, "Hi"))
+		end)
+		jestExpect(root).toMatchRenderedOutput(React.createElement("div", nil, "Hi"))
+		-- But the refs still should have been swapped.
+		jestExpect(ref1.current).toBe(nil)
+		jestExpect(ref2.current).never.toBe(nil)
+	end)
+
+	it("throw if a string ref is passed to a ref-receiving component", function()
+		local refProp
+		local function Child(props)
+			-- This component renders successfully because the ref type check does not
+			-- occur until you pass it to a component that accepts refs.
+			--
+			-- So the div will throw, but not Child.
+			refProp = props.ref
+			return React.createElement("div", { ref = props.ref })
+		end
+
+		local Owner = React.Component:extend("Owner")
+		function Owner:render()
+			return React.createElement(Child, { ref = "child" })
+		end
+
+		local root = ReactNoop.createRoot()
+		-- ROBLOX DEVIATION: ReactNoop.act is synchronous in React-Luau, so Jest-Lua
+		-- observes the thrown error directly instead of through Promise rejection.
+		jestExpect(function()
+			ReactNoop.act(function()
+				root.render(React.createElement(Owner))
+			end)
+		end).toThrow("Expected ref to be a function")
+		jestExpect(refProp).toBe("child")
+	end)
+
+	it("strings refs can be codemodded to callback refs", function()
+		local app
+		local App = React.Component:extend("App")
+		function App:render()
+			app = self
+			return React.createElement("div", {
+				prop = "Hello!",
+				ref = function(element)
+					-- `refs` used to be a shared frozen object unless/until a string
+					-- ref attached by the reconciler, but it's not anymore so that we
+					-- can codemod string refs to userspace callback refs.
+					-- ROBLOX DEVIATION: React-Luau names this field __refs.
+					self.__refs.div = element
+				end,
+			})
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(App))
+		end)
+		jestExpect(app.__refs.div.prop).toBe("Hello!")
+	end)
+
+	it("class refs are initialized to a frozen shared object", function()
+		local refsCollection = Set.new()
+		local Component = React.Component:extend("Component")
+		function Component:init()
+			-- ROBLOX DEVIATION: React-Luau class constructors are init methods and
+			-- name the refs field __refs.
+			refsCollection:add(self.__refs)
+		end
+		function Component:render()
+			return React.createElement("div")
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(React.Fragment, nil, {
+				React.createElement(Component),
+				React.createElement(Component),
+			}))
+		end)
+
+		jestExpect(refsCollection.size).toBe(1)
+		-- ROBLOX DEVIATION: Use Luau's Set iterator and table.isfrozen in place
+		-- of Array.from and Object.isFrozen.
+		local refsInstance
+		for _, value in refsCollection do
+			refsInstance = value
+			break
+		end
+		jestExpect(table.isfrozen(refsInstance)).toBe(_G.__DEV__)
+	end)
+end)

--- a/modules/react-shallow-renderer/src/init.lua
+++ b/modules/react-shallow-renderer/src/init.lua
@@ -699,8 +699,20 @@ function ReactShallowRenderer:render(element, maybeContext)
 									)
 								)
 							end
+							-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L397-L422
+							-- ROBLOX DEVIATION: React 19 removes react-shallow-renderer. React-Luau
+							-- still ships it, so mirror the reconciler's forwardRef compatibility path.
+							local propsWithoutRef = element.props
+							if element.props.ref ~= nil then
+								propsWithoutRef = {}
+								for key, value in element.props do
+									if key ~= "ref" then
+										propsWithoutRef[key] = value
+									end
+								end
+							end
 							self._rendered =
-								elementType.render(element.props, element.ref)
+								elementType.render(propsWithoutRef, element.props.ref)
 						else
 							self._rendered = elementType(element.props, self._context)
 						end

--- a/modules/react/src/ReactElement.lua
+++ b/modules/react/src/ReactElement.lua
@@ -38,6 +38,7 @@ local getComponentName = require(Packages.Shared).getComponentName
 -- ROBLOX deviation END
 local REACT_ELEMENT_TYPE = require(Packages.Shared).ReactSymbols.REACT_ELEMENT_TYPE
 local ReactCurrentOwner = require(Packages.Shared).ReactSharedInternals.ReactCurrentOwner
+local enableRefAsProp = require(Packages.Shared).ReactFeatureFlags.enableRefAsProp
 --local hasOwnProperty = Object.prototype.hasOwnProperty
 -- ROBLOX deviation START: upstream iterates over this table, but we manually unroll those loops for hot path performance
 -- IF THIS TABLE UPDATES, YOU MUST UPDATE THE UNROLLED LOOPS AS WELL
@@ -50,9 +51,11 @@ local RESERVED_PROPS = {
 -- ROBLOX deviation END
 
 local specialPropKeyWarningShown, specialPropRefWarningShown, didWarnAboutStringRefs
+local didWarnAboutElementRef
 
 if __DEV__ then
 	didWarnAboutStringRefs = {}
+	didWarnAboutElementRef = {}
 end
 
 local exports = {}
@@ -123,6 +126,10 @@ local function defineKeyPropWarningGetter(props, displayName: string)
 end
 
 local function defineRefPropWarningGetter(props, displayName: string)
+	if enableRefAsProp then
+		return
+	end
+
 	-- deviation: Use a __call metamethod here to make this function-like, but
 	-- still able to have the `isReactWarning` flag defined on it
 	local warnAboutAccessingRef = function()
@@ -154,6 +161,23 @@ local function defineRefPropWarningGetter(props, displayName: string)
 			return nil :: any
 		end,
 	})
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/jsx/ReactJSXElement.js#L113-L128
+local function elementRefGetterWithDeprecationWarning(element)
+	if __DEV__ then
+		local componentName = getComponentName(element.type) or "Unknown"
+		if not didWarnAboutElementRef[componentName] then
+			didWarnAboutElementRef[componentName] = true
+			console.error(
+				"Accessing element.ref was removed in React 19. ref is now a "
+					.. "regular prop. It will be removed from the JSX Element "
+					.. "type in a future release."
+			)
+		end
+
+		return element.props.ref
+	end
 end
 
 local function warnIfStringRefCannotBeAutoConverted(config)
@@ -217,15 +241,26 @@ local function ReactElement<P, T>(
 	props: P
 ): ReactElement<P, T>
 	-- ROBLOX deviation END
-	local element = {
-		-- Built-in properties that belong on the element
-		type = type_,
-		key = key,
-		ref = ref,
-		props = props,
-		-- Record the component responsible for creating this element.
-		_owner = owner,
-	}
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/jsx/ReactJSXElement.js#L150-L223
+	local resolvedRef = if enableRefAsProp then (props :: any).ref else ref
+	local element = if __DEV__ and enableRefAsProp
+		then {
+			-- Built-in properties that belong on the element
+			type = type_,
+			key = key,
+			props = props,
+			-- Record the component responsible for creating this element.
+			_owner = owner,
+		}
+		else {
+			-- Built-in properties that belong on the element
+			type = type_,
+			key = key,
+			ref = resolvedRef,
+			props = props,
+			-- Record the component responsible for creating this element.
+			_owner = owner,
+		}
 
 	-- This tag allows us to uniquely identify this as a React Element
 	element["$$typeof"] = REACT_ELEMENT_TYPE
@@ -253,13 +288,24 @@ local function ReactElement<P, T>(
 			end,
 		})
 		-- self and source are DEV only properties.
+		-- ROBLOX DEVIATION: Luau uses one __index metamethod for the non-enumerable
+		-- element.ref compatibility getter and the existing DEV-only fields.
 		setmetatable(element, {
-			__index = {
-				_self = self,
-				-- Two elements created in two different places should be considered
-				-- equal for testing purposes and therefore we hide it from enumeration.
-				_source = source,
-			},
+			__index = function(_, property)
+				if property == "ref" then
+					if resolvedRef ~= nil then
+						return elementRefGetterWithDeprecationWarning(element)
+					end
+					return nil
+				elseif property == "_self" then
+					return self
+				elseif property == "_source" then
+					-- Two elements created in two different places should be considered
+					-- equal for testing purposes and therefore we hide it from enumeration.
+					return source
+				end
+				return nil
+			end,
 		})
 	end
 
@@ -423,9 +469,14 @@ local function createElement<P, T>(
 		-- ROBLOX deviation START: inline hasValidRef and hasValidKey success in hot path, still call in error case for warning
 		-- ROBLOX FIXME Luau: needs normalization: Type 'P & React_ElementProps<T>' could not be converted into 'React_ElementProps<T>'; none of the intersection parts are compatible
 		if hasValidRef(config :: any) then
-			ref = ((config :: any) :: React_ElementProps<T>).ref
+			if not enableRefAsProp then
+				ref = ((config :: any) :: React_ElementProps<T>).ref
+			end
 
-			if __DEV__ then
+			-- ROBLOX DEVIATION: React-Luau's legacy string-ref warning is a hard
+			-- error. With ref-as-prop enabled, defer validation to the receiving
+			-- host/class component so function components can observe the prop.
+			if __DEV__ and not enableRefAsProp then
 				warnIfStringRefCannotBeAutoConverted(
 					(config :: any) :: React_ElementProps<T>
 				)
@@ -460,7 +511,7 @@ local function createElement<P, T>(
 		if props.key ~= nil then
 			props.key = nil
 		end
-		if props.ref ~= nil then
+		if not enableRefAsProp and props.ref ~= nil then
 			props.ref = nil
 		end
 		if props.__self ~= nil then
@@ -517,7 +568,7 @@ local function createElement<P, T>(
 	end
 
 	if __DEV__ then
-		if key or ref then
+		if key or (not enableRefAsProp and ref) then
 			-- ROBLOX deviation START: Lua can't store fields like displayName on functions
 			local displayName
 
@@ -539,7 +590,7 @@ local function createElement<P, T>(
 				defineKeyPropWarningGetter(props, displayName)
 			end
 
-			if ref then
+			if not enableRefAsProp and ref then
 				defineRefPropWarningGetter(props, displayName)
 			end
 		end
@@ -558,14 +609,14 @@ local function createElement<P, T>(
 
 	-- ROBLOX FIXME Luau: this cast is needed until normalization lands
 	return ReactElement(
-		type_,
-		key,
-		ref,
-		self,
-		source,
-		ReactCurrentOwner.current,
-		props
-	) :: any
+			type_,
+			key,
+			ref,
+			self,
+			source,
+			ReactCurrentOwner.current,
+			props
+		) :: any
 end
 exports.createElement = createElement
 
@@ -591,7 +642,7 @@ exports.cloneAndReplaceKey = function<P, T>(
 	local newElement = ReactElement(
 		oldElement.type,
 		newKey,
-		oldElement.ref,
+		if enableRefAsProp then nil else oldElement.ref,
 		oldElement._self,
 		oldElement._source,
 		oldElement._owner,
@@ -628,7 +679,7 @@ exports.cloneElement = function<P, T>(
 
 	-- Reserved names are extracted
 	local key = element.key
-	local ref = element.ref
+	local ref = if enableRefAsProp then nil else element.ref
 
 	-- Self is preserved since the owner is preserved.
 	-- ROBLOX deviation: _self field only used for string ref checking
@@ -646,8 +697,10 @@ exports.cloneElement = function<P, T>(
 		-- ROBLOX deviation START: inline hasValidRef and hasValidKey success in hot path, still call in error case for warning
 		local configRef = config.ref
 		if configRef ~= nil then
-			-- Silently steal the ref from the parent.
-			ref = configRef
+			if not enableRefAsProp then
+				-- Silently steal the ref from the parent.
+				ref = configRef
+			end
 			owner = ReactCurrentOwner.current
 		else
 			hasValidRef(config)
@@ -678,7 +731,13 @@ exports.cloneElement = function<P, T>(
 	-- on nil in JS, so we check for nil before iterating
 	if config ~= nil then
 		for propName, _ in config :: any do
-			if (config :: any)[propName] ~= nil and not RESERVED_PROPS[propName] then
+			if
+				(config :: any)[propName] ~= nil
+				and (
+					not RESERVED_PROPS[propName]
+					or (enableRefAsProp and propName == "ref")
+				)
+			then
 				if (config :: any)[propName] == nil and defaultProps ~= nil then
 					-- Resolve default props
 					-- ROBLOX FIXME Luau: force-cast required to avoid TypeError: Expected type table, got 'P' instead

--- a/modules/react/src/ReactElementValidator.lua
+++ b/modules/react/src/ReactElementValidator.lua
@@ -44,6 +44,7 @@ local REACT_ELEMENT_TYPE = ReactSymbols.REACT_ELEMENT_TYPE
 
 local warnAboutSpreadingKeyToJSX =
 	require(Packages.Shared).ReactFeatureFlags.warnAboutSpreadingKeyToJSX
+local enableRefAsProp = require(Packages.Shared).ReactFeatureFlags.enableRefAsProp
 local checkPropTypes = require(Packages.Shared).checkPropTypes
 local ReactCurrentOwner = require(Packages.Shared).ReactSharedInternals.ReactCurrentOwner
 
@@ -361,7 +362,8 @@ local function validateFragmentProps<P>(fragment: ReactElement<P & Object, any>)
 			end
 		end
 
-		if fragment.ref ~= nil then
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/c46fc90b670fb93e9a5558a36d0367cc735f812e/packages/react/src/jsx/ReactJSXElement.js#L1047-L1057
+		if not enableRefAsProp and fragment.ref ~= nil then
 			setCurrentlyValidatingElement(fragment)
 			console.error("Invalid attribute `ref` supplied to `React.Fragment`.")
 			setCurrentlyValidatingElement(nil)

--- a/modules/react/src/__tests__/ReactElement.roblox.spec.lua
+++ b/modules/react/src/__tests__/ReactElement.roblox.spec.lua
@@ -2,6 +2,7 @@
 -- ROBLOX upstream: https://github.com/facebook/react/blob/702fad4b1b48ac8f626ed3f35e8f86f5ea728084/packages/react/src/__tests__/ReactElement-test.js
 
 local Packages = script.Parent.Parent.Parent
+local React = require(script.Parent.Parent)
 local ReactElement = require(script.Parent.Parent.ReactElement)
 local JestGlobals = require(Packages.Dev.JestGlobals)
 local jestExpect = JestGlobals.expect
@@ -136,5 +137,29 @@ describe("should accept", function()
 
 		jestExpect(element).toBeDefined()
 		jestExpect(element.props.Value).toEqual(false)
+	end)
+end)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/__tests__/ReactCreateElement-test.js#L126-L140
+describe("ReactCreateElement", function()
+	it("does not extract ref from the rest of the props", function()
+		local ComponentClass = React.Component:extend("ComponentClass")
+		local ref = React.createRef()
+		local elementWithRef = React.createElement(ComponentClass, {
+			key = "12",
+			ref = ref,
+			foo = "56",
+		})
+
+		jestExpect(elementWithRef.type).toBe(ComponentClass)
+		jestExpect(function()
+			jestExpect(elementWithRef.ref).toBe(ref)
+		end).toErrorDev("Accessing element.ref was removed in React 19", {
+			withoutStack = true,
+		})
+		jestExpect(elementWithRef.props).toEqual({
+			foo = "56",
+			ref = ref,
+		})
 	end)
 end)

--- a/modules/shared/src/ReactFeatureFlags.lua
+++ b/modules/shared/src/ReactFeatureFlags.lua
@@ -101,6 +101,9 @@ exports.enableComponentStackLocations = true
 
 exports.enableNewReconciler = true
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/7b636d223838fd24b646ce19fece9f33b659d572/packages/shared/ReactFeatureFlags.js#L181-L187
+exports.enableRefAsProp = true
+
 -- Errors that are thrown while unmounting (or after in the case of passive effects)
 -- should bypass any error boundaries that are also unmounting (or have unmounted)
 -- and be handled by the nearest still-mounted boundary.


### PR DESCRIPTION
## Summary

Backport React 19's ref-as-prop behavior through the element and reconciler paths from facebook/react#28348, #28464, and #28719. Preserve legacy `forwardRef`, class component, and `element.ref` compatibility while moving ref validation to receiving fibers. Port the complete upstream `ReactFiberRefs` and `ReactClassComponentPropResolution` suites plus the classic `createElement` ref-prop case, with each React-Luau deviation stated beside the translated code.

Generated with Codex.