### PR TITLE
Backport React 19 callback ref cleanup functions

### DIFF
--- a/modules/react-reconciler/src/ReactChildFiber.new.lua
+++ b/modules/react-reconciler/src/ReactChildFiber.new.lua
@@ -12,7 +12,6 @@ local Packages = script.Parent.Parent
 local ReactGlobals = require(Packages.ReactGlobals)
 local LuauPolyfill = require(Packages.LuauPolyfill)
 local Array = LuauPolyfill.Array
-local Error = LuauPolyfill.Error
 type Array<T> = { [number]: T }
 type Set<T> = { [T]: boolean }
 type Object = { [any]: any }
@@ -147,156 +146,12 @@ end
 
 local isArray = Array.isArray
 
-function coerceRef(returnFiber: Fiber, current: Fiber | nil, element: ReactElement)
-	local mixedRef = element.ref
-	if mixedRef ~= nil and type(mixedRef) == "string" then
-		-- ROBLOX deviation: we do not support string refs, and will not coerce
-		if
-			not element._owner
-			or not element._self
-			or element._owner.stateNode == element._self
-		then
-			-- ROBLOX performance: don't get component name unless we have to use it
-			local componentName
-			if __DEV__ then
-				componentName = getComponentName(returnFiber.type) or "Component"
-			else
-				componentName = "<enable __DEV__ mode for component names>"
-			end
-			error(
-				Error.new(
-					string.format(
-						'Component "%s" contains the string ref "%s". Support for string refs '
-							-- ROBLOX deviation: we removed string ref support ahead of upstream schedule
-							.. "has been removed. We recommend using "
-							.. "useRef() or createRef() instead. "
-							.. "Learn more about using refs safely here: "
-							.. "https://reactjs.org/link/strict-mode-string-ref",
-						componentName,
-						tostring(mixedRef)
-					)
-				)
-			)
-		end
-
-		if not element._owner then
-			error(
-				"Expected ref to be a function or an object returned by React.createRef(), or nil."
-			)
-		end
-
-		-- if __DEV__ then
-		-- 	-- TODO: Clean this up once we turn on the string ref warning for
-		-- 	-- everyone, because the strict mode case will no longer be relevant
-		-- 	if
-		-- 		(bit32.band(returnFiber.mode, StrictMode) ~= 0 or warnAboutStringRefs)
-		-- 		-- We warn in ReactElement.js if owner and self are equal for string refs
-		-- 		-- because these cannot be automatically converted to an arrow function
-		-- 		-- using a codemod. Therefore, we don't have to warn about string refs again.
-		-- 		and not (
-		-- 			element._owner
-		-- 			and element._self
-		-- 			and element._owner.stateNode ~= element._self
-		-- 		)
-		-- 	then
-		-- 		local componentName = getComponentName(returnFiber.type) or "Component"
-		-- 		if not didWarnAboutStringRefs[componentName] then
-		-- 			if warnAboutStringRefs then
-		-- 				console.error(
-		-- 					'Component "%s" contains the string ref "%s". Support for string refs '
-		-- 						.. "will be removed in a future major release. We recommend using "
-		-- 						.. "useRef() or createRef() instead. "
-		-- 						.. "Learn more about using refs safely here: "
-		-- 						.. "https://reactjs.org/link/strict-mode-string-ref",
-		-- 					componentName,
-		-- 					mixedRef
-		-- 				)
-		-- 			else
-		-- 				console.error(
-		-- 					'A string ref, "%s", has been found within a strict mode tree. '
-		-- 						.. "String refs are a source of potential bugs and should be avoided. "
-		-- 						.. "We recommend using useRef() or createRef() instead. "
-		-- 						.. "Learn more about using refs safely here: "
-		-- 						.. "https://reactjs.org/link/strict-mode-string-ref",
-		-- 					mixedRef
-		-- 				)
-		-- 			end
-		-- 			didWarnAboutStringRefs[componentName] = true
-		-- 		end
-		-- 	end
-		-- end
-
-		-- if element._owner then
-		-- 	local owner: Fiber? = element._owner
-		-- 	local inst
-		-- 	if owner then
-		-- 		local ownerFiber = owner
-		-- 		invariant(
-		-- 			ownerFiber.tag == ClassComponent,
-		-- 			"Function components cannot have string refs. "
-		-- 				.. "We recommend using useRef() instead. "
-		-- 				.. "Learn more about using refs safely here: "
-		-- 				.. "https://reactjs.org/link/strict-mode-string-ref"
-		-- 		)
-		-- 		inst = ownerFiber.stateNode
-		-- 	end
-		-- 	invariant(
-		-- 		inst,
-		-- 		"Missing owner for string ref %s. This error is likely caused by a "
-		-- 			.. "bug in React. Please file an issue.",
-		-- 		mixedRef
-		-- 	)
-
-		-- 	-- ROBLOX deviation: explicitly convert to string
-		-- 	local stringRef = tostring(mixedRef)
-		-- 	-- Check if previous string ref matches new string ref
-		-- 	if
-		-- 		current ~= nil
-		-- 		and (current :: Fiber).ref ~= nil
-		-- 		-- ROBLOX deviation: Lua doesn't support fields on functions, so invert this check
-		-- 		-- typeof((current :: Fiber).ref) == 'function' and
-		-- 		and typeof((current :: Fiber).ref) ~= "function"
-		-- 		-- ROBLOX deviation: this partially inlines the ref type from Fiber to workaround Luau refinement issues
-		-- 		and ((current :: Fiber).ref :: { _stringRef: string? })._stringRef
-		-- 			== stringRef
-		-- 	then
-		-- 		return (current :: Fiber).ref
-		-- 	end
-		-- 	-- ROBLOX deviation: make ref a callable table rather than a function
-		-- 	local callableRef = function(value)
-		-- 		local refs = inst.__refs
-		-- 		if refs == emptyRefsObject then
-		-- 			-- This is a lazy pooled frozen object, so we need to initialize.
-		-- 			inst.__refs = {}
-		-- 			refs = inst.__refs
-		-- 		end
-		-- 		if value == nil then
-		-- 			refs[stringRef] = nil
-		-- 		else
-		-- 			refs[stringRef] = value
-		-- 		end
-		-- 	end
-		-- 	local ref = setmetatable({}, { __call = callableRef })
-		-- 	ref._stringRef = stringRef
-		-- 	return ref
-		-- else
-		-- 	invariant(
-		-- 		typeof(mixedRef) == "string",
-		-- 		"Expected ref to be a function, a string, an object returned by React.createRef(), or nil."
-		-- 	)
-		-- 	invariant(
-		-- 		element._owner,
-		-- 		"Element ref was specified as a string (%s) but no owner was set. This could happen for one of"
-		-- 			.. " the following reasons:\n"
-		-- 			.. "1. You may be adding a ref to a function component\n"
-		-- 			.. "2. You may be adding a ref to a component that was not created inside a component's render method\n"
-		-- 			.. "3. You have multiple copies of React loaded\n"
-		-- 			.. "See https://reactjs.org/link/refs-must-have-owner for more information.",
-		-- 		mixedRef
-		-- 	)
-		-- end
-	end
-	return mixedRef
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactChildFiber.js#L253-L262
+function coerceRef(_returnFiber: Fiber, _current: Fiber | nil, element: ReactElement)
+	-- TODO: This is a temporary, intermediate step. Now that enableRefAsProp is on,
+	-- we should resolve the `ref` prop during the begin phase of the component
+	-- it's attached to (HostComponent, ClassComponent, etc).
+	return element.props.ref
 end
 
 -- ROBLOX performance: all uses commented out

--- a/modules/react-reconciler/src/ReactFiber.new.lua
+++ b/modules/react-reconciler/src/ReactFiber.new.lua
@@ -191,6 +191,8 @@ local function createFiber(
 		index = 1,
 
 		-- node.ref = nil
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L151-L152
+		-- node.refCleanup = nil
 
 		pendingProps = pendingProps,
 		-- memoizedProps = nil
@@ -381,6 +383,8 @@ local function createWorkInProgress(current: Fiber, pendingProps: any): Fiber
 	workInProgress.sibling = current.sibling
 	workInProgress.index = current.index
 	workInProgress.ref = current.ref
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L339-L340
+	workInProgress.refCleanup = current.refCleanup
 
 	if enableProfilerTimer then
 		workInProgress.selfBaseDuration = current.selfBaseDuration
@@ -973,6 +977,8 @@ local function assignFiberPropertiesInDEV(target: Fiber, source: Fiber): Fiber
 	target.sibling = source.sibling
 	target.index = source.index
 	target.ref = source.ref
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L884-L885
+	target.refCleanup = source.refCleanup
 	target.pendingProps = source.pendingProps
 	target.memoizedProps = source.memoizedProps
 	target.updateQueue = source.updateQueue

--- a/modules/react-reconciler/src/ReactFiber.new.lua
+++ b/modules/react-reconciler/src/ReactFiber.new.lua
@@ -191,7 +191,7 @@ local function createFiber(
 		index = 1,
 
 		-- node.ref = nil
-		-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L151-L152
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L145-L146
 		-- node.refCleanup = nil
 
 		pendingProps = pendingProps,
@@ -383,7 +383,7 @@ local function createWorkInProgress(current: Fiber, pendingProps: any): Fiber
 	workInProgress.sibling = current.sibling
 	workInProgress.index = current.index
 	workInProgress.ref = current.ref
-	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L339-L340
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L317-L321
 	workInProgress.refCleanup = current.refCleanup
 
 	if enableProfilerTimer then
@@ -977,7 +977,7 @@ local function assignFiberPropertiesInDEV(target: Fiber, source: Fiber): Fiber
 	target.sibling = source.sibling
 	target.index = source.index
 	target.ref = source.ref
-	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L884-L885
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiber.new.js#L828-L838
 	target.refCleanup = source.refCleanup
 	target.pendingProps = source.pendingProps
 	target.memoizedProps = source.memoizedProps

--- a/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
@@ -397,6 +397,26 @@ local function updateForwardRef(
 	local render = Component.render
 	local ref = workInProgress.ref
 
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L397-L422
+	local propsWithoutRef
+	-- ROBLOX DEVIATION: A Luau table cannot contain a key whose value is nil, so
+	-- checking the value is equivalent to JavaScript's `in` check here.
+	-- ROBLOX DEVIATION: Access through the existing module table to avoid another
+	-- local in a file that is at Luau's local register limit.
+	if ReactFeatureFlags.enableRefAsProp and nextProps.ref ~= nil then
+		-- `ref` is just a prop now, but `forwardRef` expects it to not appear in
+		-- the props object. This used to happen in the JSX runtime, but now we do
+		-- it here.
+		propsWithoutRef = {}
+		for key, value in nextProps do
+			if key ~= "ref" then
+				propsWithoutRef[key] = value
+			end
+		end
+	else
+		propsWithoutRef = nextProps
+	end
+
 	-- The rest is a fork of updateFunctionComponent
 	local nextChildren
 	prepareToReadContext(
@@ -407,8 +427,14 @@ local function updateForwardRef(
 	if __DEV__ then
 		ReactCurrentOwner.current = workInProgress
 		setIsRendering(true)
-		nextChildren =
-			renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes)
+		nextChildren = renderWithHooks(
+			current,
+			workInProgress,
+			render,
+			propsWithoutRef,
+			ref,
+			renderLanes
+		)
 		if
 			debugRenderPhaseSideEffectsForStrictMode
 			and bit32.band(workInProgress.mode, StrictMode) ~= 0
@@ -420,7 +446,7 @@ local function updateForwardRef(
 				current,
 				workInProgress,
 				render,
-				nextProps,
+				propsWithoutRef,
 				ref,
 				renderLanes
 			)
@@ -436,8 +462,14 @@ local function updateForwardRef(
 		end
 		setIsRendering(false)
 	else
-		nextChildren =
-			renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes)
+		nextChildren = renderWithHooks(
+			current,
+			workInProgress,
+			render,
+			propsWithoutRef,
+			ref,
+			renderLanes
+		)
 	end
 
 	if current ~= nil and not didReceiveUpdate then
@@ -803,13 +835,24 @@ function updateProfiler(current: Fiber | nil, workInProgress: Fiber, renderLanes
 end
 
 local function markRef(current: Fiber | nil, workInProgress: Fiber)
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L1039-L1058
+	-- ROBLOX DEVIATION: This React 17 fork does not have the RefStatic flag.
 	local ref = workInProgress.ref
-	if
-		(current == nil and ref ~= nil)
-		or (current ~= nil and (current :: Fiber).ref ~= ref)
-	then
-		-- Schedule a Ref effect
-		workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+	if ref == nil then
+		if current ~= nil and (current :: Fiber).ref ~= nil then
+			-- Schedule a Ref effect
+			workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+		end
+	else
+		if type(ref) ~= "function" and type(ref) ~= "table" then
+			error(
+				"Expected ref to be a function, an object returned by React.createRef(), or undefined/null."
+			)
+		end
+		if current == nil or (current :: Fiber).ref ~= ref then
+			-- Schedule a Ref effect
+			workInProgress.flags = bit32.bor(workInProgress.flags, Ref)
+		end
 	end
 end
 
@@ -1357,7 +1400,12 @@ local function mountLazyComponent(
 	workInProgress.type = Component
 	workInProgress.tag = resolveLazyComponentTag(Component)
 	local resolvedTag = workInProgress.tag
-	local resolvedProps = resolveDefaultProps(Component, props)
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L1677-L1727
+	-- ROBLOX DEVIATION: Access through the existing module table to avoid another
+	-- local in a file that is at Luau's local register limit.
+	local resolvedProps = if resolvedTag == ClassComponent
+		then ReactFiberClassComponent.resolveClassComponentProps(Component, props, false)
+		else resolveDefaultProps(Component, props)
 	local child
 	if resolvedTag == FunctionComponent then
 		if __DEV__ then
@@ -1741,7 +1789,7 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any)
 		--     )
 		--   end
 		-- end
-		if workInProgress.ref ~= nil then
+		if not ReactFeatureFlags.enableRefAsProp and workInProgress.ref ~= nil then
 			local info = ""
 			local ownerName = getCurrentFiberOwnerNameInDevOrNull()
 			if ownerName then
@@ -3516,8 +3564,12 @@ local function beginWork(current: any, workInProgress: Fiber, renderLanes: Lanes
 	elseif workInProgress.tag == ClassComponent then
 		local Component = workInProgress.type
 		local unresolvedProps = workInProgress.pendingProps
-		local resolvedProps = workInProgress.elementType == Component and unresolvedProps
-			or resolveDefaultProps(Component, unresolvedProps)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L3738-L3752
+		local resolvedProps = ReactFiberClassComponent.resolveClassComponentProps(
+			Component,
+			unresolvedProps,
+			workInProgress.elementType == Component
+		)
 		return updateClassComponent(
 			current,
 			workInProgress,
@@ -3600,8 +3652,12 @@ local function beginWork(current: any, workInProgress: Fiber, renderLanes: Lanes
 	elseif workInProgress.tag == IncompleteClassComponent then
 		local Component = workInProgress.type
 		local unresolvedProps = workInProgress.pendingProps
-		local resolvedProps = workInProgress.elementType == Component and unresolvedProps
-			or resolveDefaultProps(Component, unresolvedProps)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L3827-L3844
+		local resolvedProps = ReactFiberClassComponent.resolveClassComponentProps(
+			Component,
+			unresolvedProps,
+			workInProgress.elementType == Component
+		)
 		return mountIncompleteClassComponent(
 			current,
 			workInProgress,

--- a/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
+++ b/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
@@ -43,6 +43,7 @@ local enableDebugTracing = ReactFeatureFlags.enableDebugTracing
 local enableSchedulingProfiler = ReactFeatureFlags.enableSchedulingProfiler
 local warnAboutDeprecatedLifecycles = ReactFeatureFlags.warnAboutDeprecatedLifecycles
 local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffects
+local enableRefAsProp = ReactFeatureFlags.enableRefAsProp
 
 local ReactStrictModeWarnings = require(script.Parent["ReactStrictModeWarnings.new"])
 local isMounted = require(script.Parent.ReactFiberTreeReflection).isMounted
@@ -58,8 +59,7 @@ local ReactSymbols = require(Packages.Shared).ReactSymbols
 local REACT_CONTEXT_TYPE = ReactSymbols.REACT_CONTEXT_TYPE
 local REACT_PROVIDER_TYPE = ReactSymbols.REACT_PROVIDER_TYPE
 
-local resolveDefaultProps =
-	require(script.Parent["ReactFiberLazyComponent.new"]).resolveDefaultProps
+local resolveClassComponentProps
 local ReactTypeOfMode = require(script.Parent.ReactTypeOfMode)
 local DebugTracingMode = ReactTypeOfMode.DebugTracingMode
 local StrictMode = ReactTypeOfMode.StrictMode
@@ -110,10 +110,6 @@ local fakeInternalInstance = {}
 
 -- React.Component uses a shared frozen object by default.
 -- We'll use it to determine whether we need to initialize legacy refs.
--- ROBLOX deviation: Uses __refs instead of refs to avoid conflicts
--- local emptyRefsObject = React.Component:extend("").refs
-local emptyRefsObject = React.Component:extend("").__refs
-
 local didWarnAboutStateAssignmentForComponent
 local didWarnAboutUninitializedState
 local didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate
@@ -958,9 +954,9 @@ local function mountClassInstance(
 	local instance = workInProgress.stateNode
 	instance.props = newProps
 	instance.state = workInProgress.memoizedState
-	-- ROBLOX deviation: Uses __refs instead of refs to avoid conflicts
-	-- instance.refs = emptyRefsObject
-	instance.__refs = emptyRefsObject
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberClassComponent.js#L768-L783
+	-- ROBLOX DEVIATION: React-Luau uses __refs instead of refs to avoid conflicts.
+	instance.__refs = {}
 
 	initializeUpdateQueue(workInProgress)
 
@@ -1064,8 +1060,16 @@ function resumeMountClassInstance(
 ): boolean
 	local instance = workInProgress.stateNode
 
-	local oldProps = workInProgress.memoizedProps
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/bc1fac0e9da23990469d328e330aafdd364759b8/packages/react-reconciler/src/ReactFiberClassComponent.js#L904-L938
+	local unresolvedOldProps = workInProgress.memoizedProps
+	local oldProps = resolveClassComponentProps(
+		ctor,
+		unresolvedOldProps,
+		workInProgress.type == workInProgress.elementType
+	)
 	instance.props = oldProps
+	local unresolvedNewProps = workInProgress.pendingProps
+	local didReceiveNewProps = unresolvedNewProps ~= unresolvedOldProps
 
 	local oldContext = instance.context
 	local contextType = ctor.contextType
@@ -1096,7 +1100,7 @@ function resumeMountClassInstance(
 			or type(instance.componentWillReceiveProps) == "function"
 		)
 	then
-		if oldProps ~= newProps or oldContext ~= nextContext then
+		if didReceiveNewProps or oldContext ~= nextContext then
 			callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext)
 		end
 	end
@@ -1109,7 +1113,7 @@ function resumeMountClassInstance(
 	processUpdateQueue(workInProgress, newProps, instance, renderLanes)
 	newState = workInProgress.memoizedState
 	if
-		oldProps == newProps
+		not didReceiveNewProps
 		and oldState == newState
 		and not hasContextChanged()
 		and not checkHasForceUpdateAfterProcessing()
@@ -1216,9 +1220,11 @@ local function updateClassInstance(
 	cloneUpdateQueue(current, workInProgress)
 
 	local unresolvedOldProps = workInProgress.memoizedProps
-	local oldProps = if workInProgress.type == workInProgress.elementType
-		then unresolvedOldProps
-		else resolveDefaultProps(workInProgress.type, unresolvedOldProps)
+	local oldProps = resolveClassComponentProps(
+		ctor,
+		unresolvedOldProps,
+		workInProgress.type == workInProgress.elementType
+	)
 	instance.props = oldProps
 	local unresolvedNewProps = workInProgress.pendingProps
 
@@ -1420,14 +1426,45 @@ local function updateClassInstance(
 	return shouldUpdate
 end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/8a13ea0b7a4b161add410779e0abe2cd4cc230d2/packages/react-reconciler/src/ReactFiberClassComponent.js#L1229-L1265
+resolveClassComponentProps = function(
+	Component: any,
+	baseProps: { [any]: any },
+	alreadyResolvedDefaultProps: boolean
+): { [any]: any }
+	local newProps = baseProps
+	-- Resolve default props. Taken from old JSX runtime, where this used to live.
+	local defaultProps = Component.defaultProps
+	if defaultProps and not alreadyResolvedDefaultProps then
+		newProps = Object.assign({}, newProps, baseProps)
+		for propName, value in defaultProps do
+			if newProps[propName] == nil then
+				newProps[propName] = value
+			end
+		end
+	end
+
+	if enableRefAsProp then
+		-- Remove ref from the props object, if it exists.
+		-- ROBLOX DEVIATION: A Luau table cannot contain a key whose value is nil, so
+		-- checking the value is equivalent to JavaScript's `in` check here.
+		if newProps.ref ~= nil then
+			if newProps == baseProps then
+				newProps = Object.assign({}, newProps)
+			end
+			newProps.ref = nil
+		end
+	end
+	return newProps
+end
+
 return {
 	adoptClassInstance = adoptClassInstance,
 	constructClassInstance = constructClassInstance,
 	mountClassInstance = mountClassInstance,
 	resumeMountClassInstance = resumeMountClassInstance,
 	updateClassInstance = updateClassInstance,
+	resolveClassComponentProps = resolveClassComponentProps,
 
 	applyDerivedStateFromProps = applyDerivedStateFromProps,
-	-- deviation: this should be safe to export, since it gets assigned only once
-	emptyRefsObject = emptyRefsObject,
 }

--- a/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
@@ -308,8 +308,20 @@ end
 
 local function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber): ()
 	local ref = current.ref
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L289-L333
+	local refCleanup = current.refCleanup
 	if ref ~= nil then
-		if typeof(ref) == "function" then
+		if typeof(refCleanup) == "function" then
+			local ok, error_ = xpcall(refCleanup, describeError)
+			current.refCleanup = nil
+			local finishedWork = current.alternate
+			if finishedWork ~= nil then
+				finishedWork.refCleanup = nil
+			end
+			if not ok then
+				captureCommitPhaseError(current, nearestMountedAncestor, error_)
+			end
+		elseif typeof(ref) == "function" then
 			-- ROBLOX performance: eliminate the __DEV__ and invokeGuardedCallback, like React 18 has done
 			local ok, error_ = xpcall(ref, describeError)
 			if not ok then
@@ -1153,7 +1165,8 @@ function commitAttachRef(finishedWork: Fiber)
 		--   instanceToUse = instance
 		-- end
 		if typeof(ref) == "function" then
-			ref(instanceToUse)
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1598-L1612
+			finishedWork.refCleanup = ref(instanceToUse)
 		else
 			if __DEV__ then
 				-- ROBLOX FIXME: We won't be able to recognize a ref object by checking
@@ -1179,7 +1192,18 @@ end
 function commitDetachRef(current: Fiber)
 	local currentRef = current.ref
 	if currentRef ~= nil then
-		if typeof(currentRef) == "function" then
+		-- ROBLOX DEVIATION: React-Luau's React 17 work loop still calls this
+		-- unguarded detach path when a ref changes. Mirror safelyDetachRef's cleanup
+		-- selection and alternate nulling while retaining the existing error behavior.
+		local refCleanup = current.refCleanup
+		if typeof(refCleanup) == "function" then
+			current.refCleanup = nil
+			local finishedWork = current.alternate
+			if finishedWork ~= nil then
+				finishedWork.refCleanup = nil
+			end
+			refCleanup()
+		elseif typeof(currentRef) == "function" then
 			currentRef(nil)
 		else
 			currentRef.current = nil

--- a/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
@@ -151,8 +151,9 @@ local resetCurrentDebugFiberInDEV = ReactCurrentFiber.resetCurrentFiber
 local setCurrentDebugFiberInDEV = ReactCurrentFiber.setCurrentFiber
 local onCommitUnmount =
 	require(script.Parent["ReactFiberDevToolsHook.new"]).onCommitUnmount
-local resolveDefaultProps =
-	require(script.Parent["ReactFiberLazyComponent.new"]).resolveDefaultProps
+-- ROBLOX upstream: https://github.com/facebook/react/blob/6121c95baf590e6c4ab0ea697f4f4a07e1d898f0/packages/react-reconciler/src/ReactFiberCommitWork.js#L104-L107
+local resolveClassComponentProps =
+	require(script.Parent["ReactFiberClassComponent.new"]).resolveClassComponentProps
 local ReactProfilerTimer = require(script.Parent["ReactProfilerTimer.new"])
 local startLayoutEffectTimer = ReactProfilerTimer.startLayoutEffectTimer
 local recordPassiveEffectDuration = ReactProfilerTimer.recordPassiveEffectDuration
@@ -260,7 +261,12 @@ local nearestProfilerOnStack: Fiber | nil = nil
 -- local PossiblyWeakSet = typeof WeakSet == 'function' ? WeakSet : Set
 
 local function callComponentWillUnmountWithTimer(current, instance)
-	instance.props = current.memoizedProps
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/bc1fac0e9da23990469d328e330aafdd364759b8/packages/react-reconciler/src/ReactFiberCommitWork.js#L244-L252
+	instance.props = resolveClassComponentProps(
+		current.type,
+		current.memoizedProps,
+		current.elementType == current.type
+	)
 	instance.state = current.memoizedState
 	if
 		enableProfilerTimer
@@ -349,8 +355,13 @@ local function commitBeforeMutationLifeCycles(
 				-- but instead we rely on them being set during last render.
 				-- TODO: revisit this when we implement resuming.
 				if __DEV__ then
+					-- ROBLOX upstream: https://github.com/facebook/react/blob/8a13ea0b7a4b161add410779e0abe2cd4cc230d2/packages/react-reconciler/src/ReactFiberCommitWork.js#L472-L481
+					-- ROBLOX DEVIATION: Luau cannot distinguish an absent `ref` key from
+					-- one set to nil. The same value check is used in the lifecycle and
+					-- callback warning guards below.
 					if
-						finishedWork.type == finishedWork.elementType
+						not finishedWork.type.defaultProps
+						and finishedWork.memoizedProps.ref == nil
 						and not didWarnAboutReassigningProps
 					then
 						if instance.props ~= finishedWork.memoizedProps then
@@ -377,8 +388,11 @@ local function commitBeforeMutationLifeCycles(
 				end
 				-- deviation: Call with ':' instead of '.' so that self is available
 				local snapshot = instance:getSnapshotBeforeUpdate(
-					finishedWork.elementType == finishedWork.type and prevProps
-						or resolveDefaultProps(finishedWork.type, prevProps),
+					resolveClassComponentProps(
+						finishedWork.type,
+						prevProps,
+						finishedWork.elementType == finishedWork.type
+					),
 					prevState
 				)
 				if __DEV__ then
@@ -887,7 +901,8 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 			-- TODO: revisit this when we implement resuming.
 			if __DEV__ then
 				if
-					finishedWork.type == finishedWork.elementType
+					not finishedWork.type.defaultProps
+					and finishedWork.memoizedProps.ref == nil
 					and not didWarnAboutReassigningProps
 				then
 					if instance.props ~= finishedWork.memoizedProps then
@@ -932,16 +947,19 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 				instance:componentDidMount()
 			end
 		else
-			local prevProps = finishedWork.elementType == finishedWork.type
-					and current.memoizedProps
-				or resolveDefaultProps(finishedWork.type, current.memoizedProps)
+			local prevProps = resolveClassComponentProps(
+				finishedWork.type,
+				current.memoizedProps,
+				finishedWork.elementType == finishedWork.type
+			)
 			local prevState = current.memoizedState
 			-- We could update instance props and state here,
 			-- but instead we rely on them being set during last render.
 			-- TODO: revisit this when we implement resuming.
 			if __DEV__ then
 				if
-					finishedWork.type == finishedWork.elementType
+					not finishedWork.type.defaultProps
+					and finishedWork.memoizedProps.ref == nil
 					and not didWarnAboutReassigningProps
 				then
 					if instance.props ~= finishedWork.memoizedProps then
@@ -1002,7 +1020,8 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber)
 	if updateQueue ~= nil then
 		if __DEV__ then
 			if
-				finishedWork.type == finishedWork.elementType
+				not finishedWork.type.defaultProps
+				and finishedWork.memoizedProps.ref == nil
 				and not didWarnAboutReassigningProps
 			then
 				if instance.props ~= finishedWork.memoizedProps then

--- a/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberCommitWork.new.lua
@@ -308,10 +308,12 @@ end
 
 local function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber): ()
 	local ref = current.ref
-	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L289-L333
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L278-L334
 	local refCleanup = current.refCleanup
 	if ref ~= nil then
 		if typeof(refCleanup) == "function" then
+			-- ROBLOX DEVIATION: React-Luau keeps this older reconciler's untimed
+			-- ref-detach path; the upstream layout-effect profiler wrapper is not backported.
 			local ok, error_ = xpcall(refCleanup, describeError)
 			current.refCleanup = nil
 			local finishedWork = current.alternate
@@ -323,9 +325,15 @@ local function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber): (
 			end
 		elseif typeof(ref) == "function" then
 			-- ROBLOX performance: eliminate the __DEV__ and invokeGuardedCallback, like React 18 has done
-			local ok, error_ = xpcall(ref, describeError)
+			local ok, result = xpcall(ref, describeError)
 			if not ok then
-				captureCommitPhaseError(current, nearestMountedAncestor, error_)
+				captureCommitPhaseError(current, nearestMountedAncestor, result)
+			elseif __DEV__ and typeof(result) == "function" then
+				console.error(
+					"Unexpected return value from a callback ref in %s. "
+						.. "A callback ref should not return a function.",
+					getComponentName(current.type) or "instance"
+				)
 			end
 		else
 			-- ROBLOX FIXME Luau: next line gets Expected type table, got 'RefObject | {| [string]: any, _stringRef: string? |}' instead
@@ -1165,7 +1173,7 @@ function commitAttachRef(finishedWork: Fiber)
 		--   instanceToUse = instance
 		-- end
 		if typeof(ref) == "function" then
-			-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1598-L1612
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1513-L1541
 			finishedWork.refCleanup = ref(instanceToUse)
 		else
 			if __DEV__ then

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -1389,15 +1389,20 @@ end
 
 function imperativeHandleEffect<T>(
 	create: () -> T,
-	ref: { current: T | nil } | ((inst: T | nil) -> ...any) | nil
+	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil
 	-- ROBLOX deviation: explicit type annotation needed due to mixed return
 ): nil | () -> ...any
 	if ref ~= nil and type(ref) == "function" then
 		local refCallback = ref
 		local inst = create()
-		refCallback(inst)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-reconciler/src/ReactFiberHooks.js#L2565-L2575
+		local refCleanup = refCallback(inst)
 		return function()
-			return refCallback(nil)
+			if type(refCleanup) == "function" then
+				return refCleanup()
+			else
+				return refCallback(nil)
+			end
 		end
 	elseif ref ~= nil then
 		local refObject = ref :: any
@@ -1431,7 +1436,7 @@ function imperativeHandleEffect<T>(
 end
 
 function mountImperativeHandle<T>(
-	ref: { current: T | nil } | ((inst: T | nil) -> ...any) | nil,
+	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 	create: () -> T,
 	deps: Array<any> | nil
 ): ()
@@ -1466,7 +1471,7 @@ function mountImperativeHandle<T>(
 end
 
 function updateImperativeHandle<T>(
-	ref: { current: T | nil } | ((inst: T | nil) -> ...any) | nil,
+	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 	create: () -> T,
 	deps: Array<any> | nil
 ): ()

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -1387,15 +1387,16 @@ local function updateLayoutEffect(
 	updateEffectImpl(UpdateEffect, HookLayout, create, deps)
 end
 
+-- ROBLOX DEVIATION: Luau narrows upstream's mixed callback result to the
+-- supported cleanup function or nil throughout these imperative-handle helpers.
 function imperativeHandleEffect<T>(
 	create: () -> T,
 	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil
-	-- ROBLOX deviation: explicit type annotation needed due to mixed return
 ): nil | () -> ...any
 	if ref ~= nil and type(ref) == "function" then
 		local refCallback = ref
 		local inst = create()
-		-- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-reconciler/src/ReactFiberHooks.js#L2565-L2575
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-reconciler/src/ReactFiberHooks.js#L2405-L2420
 		local refCleanup = refCallback(inst)
 		return function()
 			if type(refCleanup) == "function" then

--- a/modules/react-reconciler/src/ReactInternalTypes.lua
+++ b/modules/react-reconciler/src/ReactInternalTypes.lua
@@ -195,7 +195,7 @@ export type Fiber = {
 		| { _stringRef: string?, [string]: any }
 		| RefObject,
 
-	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactInternalTypes.js#L134-L140
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactInternalTypes.js#L118-L125
 	refCleanup: (() -> ())?,
 
 	-- Input is the data coming into process this fiber. Arguments. Props.

--- a/modules/react-reconciler/src/ReactInternalTypes.lua
+++ b/modules/react-reconciler/src/ReactInternalTypes.lua
@@ -190,7 +190,13 @@ export type Fiber = {
 	-- I'll avoid adding an owner field for prod and model that as functions.
 	-- ROBLOX deviation: Lua doesn't allow fields on functions
 	-- ref: (((any) -> ()) & {_stringRef: string?, [string]: any}) | RefObject,
-	ref: nil | ((handle: any) -> ()) | { _stringRef: string?, [string]: any } | RefObject,
+	ref: nil
+		| ((handle: any) -> (() -> ())?)
+		| { _stringRef: string?, [string]: any }
+		| RefObject,
+
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactInternalTypes.js#L134-L140
+	refCleanup: (() -> ())?,
 
 	-- Input is the data coming into process this fiber. Arguments. Props.
 	pendingProps: any, -- This type will be more specific once we overload the tag.

--- a/modules/react-reconciler/src/__tests__/ReactClassComponentPropResolution.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactClassComponentPropResolution.spec.lua
@@ -1,0 +1,151 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/__tests__/ReactClassComponentPropResolution-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ ]]
+--!strict
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+local it = JestGlobals.it
+
+local React
+local ReactNoop
+local Scheduler
+local Object
+
+-- ROBLOX DEVIATION: React-Luau records Scheduler logs with
+-- unstable_yieldValue/toHaveYielded, and ReactNoop.act is synchronous.
+describe("ReactClassComponentPropResolution", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Dev.Scheduler)
+		Object = require(Packages.LuauPolyfill).Object
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	it("resolves ref and default props before calling lifecycle methods", function()
+		local root = ReactNoop.createRoot()
+		local function getPropKeys(props)
+			local keys = Object.keys(props)
+			-- ROBLOX DEVIATION: Luau table iteration order is unspecified.
+			table.sort(keys)
+			return table.concat(keys, ", ")
+		end
+
+		local Component = React.Component:extend("Component")
+		-- ROBLOX DEVIATION: React-Luau class constructors are init methods and
+		-- receive their props through self.props.
+		function Component:init()
+			Scheduler.unstable_yieldValue("constructor: " .. getPropKeys(self.props))
+		end
+		function Component:shouldComponentUpdate(props)
+			Scheduler.unstable_yieldValue(
+				"shouldComponentUpdate (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"shouldComponentUpdate (next props): " .. getPropKeys(props)
+			)
+			return true
+		end
+		function Component:componentDidUpdate(props)
+			Scheduler.unstable_yieldValue(
+				"componentDidUpdate (prev props): " .. getPropKeys(props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentDidUpdate (next props): " .. getPropKeys(self.props)
+			)
+			return true
+		end
+		function Component:componentDidMount()
+			Scheduler.unstable_yieldValue(
+				"componentDidMount: " .. getPropKeys(self.props)
+			)
+			return true
+		end
+		function Component:UNSAFE_componentWillMount()
+			Scheduler.unstable_yieldValue(
+				"componentWillMount: " .. getPropKeys(self.props)
+			)
+		end
+		function Component:UNSAFE_componentWillReceiveProps(nextProps)
+			Scheduler.unstable_yieldValue(
+				"componentWillReceiveProps (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentWillReceiveProps (next props): " .. getPropKeys(nextProps)
+			)
+		end
+		function Component:UNSAFE_componentWillUpdate(nextProps)
+			Scheduler.unstable_yieldValue(
+				"componentWillUpdate (prev props): " .. getPropKeys(self.props)
+			)
+			Scheduler.unstable_yieldValue(
+				"componentWillUpdate (next props): " .. getPropKeys(nextProps)
+			)
+		end
+		function Component:componentWillUnmount()
+			Scheduler.unstable_yieldValue(
+				"componentWillUnmount: " .. getPropKeys(self.props)
+			)
+		end
+		function Component:render()
+			return React.createElement(Text, {
+				text = "render: " .. getPropKeys(self.props),
+			})
+		end
+		Component.defaultProps = {
+			default = "yo",
+		}
+
+		-- `ref` should never appear as a prop. `default` always should.
+
+		-- Mount
+		local ref = React.createRef()
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { text = "Yay", ref = ref }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"constructor: default, text",
+			"componentWillMount: default, text",
+			"render: default, text",
+			"componentDidMount: default, text",
+		})
+		-- Update
+		ReactNoop.act(function()
+			root.render(
+				React.createElement(Component, { text = "Yay (again)", ref = ref })
+			)
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"componentWillReceiveProps (prev props): default, text",
+			"componentWillReceiveProps (next props): default, text",
+			"shouldComponentUpdate (prev props): default, text",
+			"shouldComponentUpdate (next props): default, text",
+			"componentWillUpdate (prev props): default, text",
+			"componentWillUpdate (next props): default, text",
+			"render: default, text",
+			"componentDidUpdate (prev props): default, text",
+			"componentDidUpdate (next props): default, text",
+		})
+		-- Unmount
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "componentWillUnmount: default, text" })
+	end)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactFiberRefs.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactFiberRefs.spec.lua
@@ -1,0 +1,183 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/__tests__/ReactFiberRefs-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ ]]
+--!strict
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+local it = JestGlobals.it
+local Set = require(Packages.LuauPolyfill).Set
+
+local React
+local ReactNoop
+local Scheduler
+
+-- ROBLOX DEVIATION: React-Luau records Scheduler logs with
+-- unstable_yieldValue/toHaveYielded, and ReactNoop.act is synchronous.
+describe("ReactFiberRefs", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Dev.Scheduler)
+	end)
+
+	it("ref is attached even if there are no other updates (class)", function()
+		local component
+		local Component = React.Component:extend("Component")
+		function Component:shouldComponentUpdate()
+			-- This component's output doesn't depend on any props or state
+			return false
+		end
+		function Component:render()
+			Scheduler.unstable_yieldValue("Render")
+			component = self
+			return "Hi"
+		end
+
+		local ref1 = React.createRef()
+		local ref2 = React.createRef()
+		local root = ReactNoop.createRoot()
+
+		-- Mount with ref1 attached
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { ref = ref1 }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "Render" })
+		jestExpect(root).toMatchRenderedOutput("Hi")
+		jestExpect(ref1.current).toBe(component)
+		-- ref2 has no value
+		jestExpect(ref2.current).toBe(nil)
+
+		-- Switch to ref2, but don't update anything else.
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { ref = ref2 }))
+		end)
+		-- The component did not re-render because no props changed.
+		jestExpect(Scheduler).toHaveYielded({})
+		jestExpect(root).toMatchRenderedOutput("Hi")
+		-- But the refs still should have been swapped.
+		jestExpect(ref1.current).toBe(nil)
+		jestExpect(ref2.current).toBe(component)
+	end)
+
+	it("ref is attached even if there are no other updates (host component)", function()
+		-- This is kind of a silly test because host components never bail out if they
+		-- receive a new element, and there's no way to update a ref without also
+		-- updating the props, but adding it here anyway for symmetry with the
+		-- class case above.
+		local ref1 = React.createRef()
+		local ref2 = React.createRef()
+		local root = ReactNoop.createRoot()
+
+		-- Mount with ref1 attached
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = ref1 }, "Hi"))
+		end)
+		jestExpect(root).toMatchRenderedOutput(React.createElement("div", nil, "Hi"))
+		jestExpect(ref1.current).never.toBe(nil)
+		-- ref2 has no value
+		jestExpect(ref2.current).toBe(nil)
+
+		-- Switch to ref2, but don't update anything else.
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = ref2 }, "Hi"))
+		end)
+		jestExpect(root).toMatchRenderedOutput(React.createElement("div", nil, "Hi"))
+		-- But the refs still should have been swapped.
+		jestExpect(ref1.current).toBe(nil)
+		jestExpect(ref2.current).never.toBe(nil)
+	end)
+
+	it("throw if a string ref is passed to a ref-receiving component", function()
+		local refProp
+		local function Child(props)
+			-- This component renders successfully because the ref type check does not
+			-- occur until you pass it to a component that accepts refs.
+			--
+			-- So the div will throw, but not Child.
+			refProp = props.ref
+			return React.createElement("div", { ref = props.ref })
+		end
+
+		local Owner = React.Component:extend("Owner")
+		function Owner:render()
+			return React.createElement(Child, { ref = "child" })
+		end
+
+		local root = ReactNoop.createRoot()
+		-- ROBLOX DEVIATION: ReactNoop.act is synchronous in React-Luau, so Jest-Lua
+		-- observes the thrown error directly instead of through Promise rejection.
+		jestExpect(function()
+			ReactNoop.act(function()
+				root.render(React.createElement(Owner))
+			end)
+		end).toThrow("Expected ref to be a function")
+		jestExpect(refProp).toBe("child")
+	end)
+
+	it("strings refs can be codemodded to callback refs", function()
+		local app
+		local App = React.Component:extend("App")
+		function App:render()
+			app = self
+			return React.createElement("div", {
+				prop = "Hello!",
+				ref = function(element)
+					-- `refs` used to be a shared frozen object unless/until a string
+					-- ref attached by the reconciler, but it's not anymore so that we
+					-- can codemod string refs to userspace callback refs.
+					-- ROBLOX DEVIATION: React-Luau names this field __refs.
+					self.__refs.div = element
+				end,
+			})
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(App))
+		end)
+		jestExpect(app.__refs.div.prop).toBe("Hello!")
+	end)
+
+	it("class refs are initialized to a frozen shared object", function()
+		local refsCollection = Set.new()
+		local Component = React.Component:extend("Component")
+		function Component:init()
+			-- ROBLOX DEVIATION: React-Luau class constructors are init methods and
+			-- name the refs field __refs.
+			refsCollection:add(self.__refs)
+		end
+		function Component:render()
+			return React.createElement("div")
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(React.Fragment, nil, {
+				React.createElement(Component),
+				React.createElement(Component),
+			}))
+		end)
+
+		jestExpect(refsCollection.size).toBe(1)
+		-- ROBLOX DEVIATION: Use Luau's Set iterator and table.isfrozen in place
+		-- of Array.from and Object.isFrozen.
+		local refsInstance
+		for _, value in refsCollection do
+			refsInstance = value
+			break
+		end
+		jestExpect(table.isfrozen(refsInstance)).toBe(_G.__DEV__)
+	end)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -1,0 +1,362 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/d4e78c42a94be027b4dc7ed2659a5fddfbf9bd4e/packages/react-dom/src/__tests__/refs-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ ]]
+--!strict
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+local it = JestGlobals.it
+
+local React
+local ReactNoop
+
+-- ROBLOX DEVIATION: React-Luau uses ReactNoop's public renderer seam instead
+-- of the DOM container, and ReactNoop.act is synchronous.
+describe("refs return clean up function", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+	end)
+
+	it("calls clean up function if it exists", function()
+		local cleanUpMock, cleanUp = jest.fn()
+		local setup = jest.fn()
+		local root = ReactNoop.createRoot()
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				ref = function(ref)
+					setup(ref)
+					return cleanUp
+				end,
+			}))
+		end)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				ref = function(ref)
+					setup(ref)
+				end,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(2)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock.mock.calls[1][1]).toBe(nil)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				ref = function() end,
+			}))
+		end)
+
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+		jestExpect(setup).toHaveBeenCalledTimes(3)
+		jestExpect(setup.mock.calls[3][1]).toBe(nil)
+
+		cleanUpMock, cleanUp = jest.fn()
+		setup = jest.fn()
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				ref = function(ref)
+					setup(ref)
+					return cleanUp
+				end,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(0)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				ref = function(ref)
+					setup(ref)
+					return cleanUp
+				end,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(2)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+	end)
+
+	it("handles ref functions with stable identity", function()
+		local cleanUpMock, cleanUp = jest.fn()
+		local setup = jest.fn()
+		local function onRefChange(ref)
+			setup(ref)
+			return cleanUp
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = onRefChange }))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(0)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				className = "niceClassName",
+				ref = onRefChange,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(0)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div"))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+	end)
+
+	it("handles detaching refs with either cleanup function or nil argument", function()
+		local cleanUpMock, cleanUp = jest.fn()
+		local setup = jest.fn()
+		local setup2 = jest.fn()
+		local nilHandler = jest.fn()
+
+		local function onRefChangeWithCleanup(ref)
+			if ref then
+				setup(ref.prop)
+			else
+				nilHandler()
+			end
+			return cleanUp
+		end
+
+		local function onRefChangeWithoutCleanup(ref)
+			if ref then
+				setup2(ref.prop)
+			else
+				nilHandler()
+			end
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				prop = "test-div",
+				ref = onRefChangeWithCleanup,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledWith("test-div")
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(0)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				prop = "test-div2",
+				ref = onRefChangeWithoutCleanup,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+		jestExpect(setup2).toHaveBeenCalledWith("test-div2")
+		jestExpect(setup2).toHaveBeenCalledTimes(1)
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				prop = "test-div3",
+				ref = onRefChangeWithCleanup,
+			}))
+		end)
+
+		jestExpect(setup2).toHaveBeenCalledWith("test-div2")
+		jestExpect(setup2).toHaveBeenCalledTimes(1)
+		jestExpect(nilHandler).toHaveBeenCalledTimes(1)
+		jestExpect(setup).toHaveBeenCalledTimes(2)
+	end)
+
+	it("calls cleanup function on unmount", function()
+		local cleanUpMock, cleanUp = jest.fn()
+		local setup = jest.fn()
+		local nilHandler = jest.fn()
+
+		local function onRefChangeWithCleanup(ref)
+			if ref then
+				setup(ref.prop)
+			else
+				nilHandler()
+			end
+			return cleanUp
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement("div", {
+				prop = "test-div",
+				ref = onRefChangeWithCleanup,
+			}))
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(0)
+		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
+
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
+	end)
+
+	-- ROBLOX DEVIATION: The upstream suite exercises host refs. This parallel
+	-- public class-ref case covers React-Luau's class receiver path.
+	it("calls cleanup function for class refs", function()
+		local cleanUpMock, cleanUp = jest.fn()
+		local setup = jest.fn()
+		local nilHandler = jest.fn()
+		local Component = React.Component:extend("Component")
+		function Component:render()
+			return nil
+		end
+
+		local function classRef(ref)
+			if ref then
+				setup(ref)
+			else
+				nilHandler()
+			end
+			return cleanUp
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(Component, { ref = classRef }))
+		end)
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+
+		jestExpect(setup).toHaveBeenCalledTimes(1)
+		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
+		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
+	end)
+end)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-dom/src/__tests__/refs-test.js#L785-L888
+describe("useImerativeHandle refs", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+	end)
+
+	local function createImperativeHandleComponent()
+		return React.forwardRef(function(props, ref)
+			React.useImperativeHandle(ref, function()
+				return {
+					greet = function()
+						return "Hello " .. props.name
+					end,
+				}
+			end, { props.name })
+			return nil
+		end)
+	end
+
+	it("should work with object style refs", function()
+		local ImperativeHandleComponent = createImperativeHandleComponent()
+		local root = ReactNoop.createRoot()
+		local ref = React.createRef()
+
+		ReactNoop.act(function()
+			root.render(React.createElement(ImperativeHandleComponent, {
+				name = "Alice",
+				ref = ref,
+			}))
+		end)
+		jestExpect(ref.current.greet()).toBe("Hello Alice")
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+		jestExpect(ref.current).toBe(nil)
+	end)
+
+	it("should work with callback style refs", function()
+		local ImperativeHandleComponent = createImperativeHandleComponent()
+		local root = ReactNoop.createRoot()
+		local current = nil
+
+		ReactNoop.act(function()
+			root.render(React.createElement(ImperativeHandleComponent, {
+				name = "Alice",
+				ref = function(ref)
+					current = ref
+				end,
+			}))
+		end)
+		jestExpect(current.greet()).toBe("Hello Alice")
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+		jestExpect(current).toBe(nil)
+	end)
+
+	it("should work with callback style refs with cleanup function", function()
+		local ImperativeHandleComponent = createImperativeHandleComponent()
+		local root = ReactNoop.createRoot()
+		local cleanupCalls = 0
+		local createCalls = 0
+		local current = nil
+
+		local function ref(nextCurrent)
+			current = nextCurrent
+			createCalls += 1
+			return function()
+				current = nil
+				cleanupCalls += 1
+			end
+		end
+
+		ReactNoop.act(function()
+			root.render(React.createElement(ImperativeHandleComponent, {
+				name = "Alice",
+				ref = ref,
+			}))
+		end)
+		jestExpect(current.greet()).toBe("Hello Alice")
+		jestExpect(createCalls).toBe(1)
+		jestExpect(cleanupCalls).toBe(0)
+
+		ReactNoop.act(function()
+			root.render(React.createElement(ImperativeHandleComponent, {
+				name = "Bob",
+				ref = ref,
+			}))
+		end)
+		jestExpect(current.greet()).toBe("Hello Bob")
+		jestExpect(createCalls).toBe(2)
+		jestExpect(cleanupCalls).toBe(1)
+
+		ReactNoop.act(function()
+			root.render(nil)
+		end)
+		jestExpect(current).toBe(nil)
+		jestExpect(createCalls).toBe(2)
+		jestExpect(cleanupCalls).toBe(2)
+	end)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -63,9 +63,8 @@ describe("refs return clean up function", function()
 
 		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
 		jestExpect(setup).toHaveBeenCalledTimes(3)
-		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as an
-		-- Object.None sentinel owned by the mock package's dependency graph.
-		jestExpect(tostring(setup.mock.calls[3][1])).toBe("Object.None")
+		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as its nil sentinel.
+		jestExpect(tostring(setup.mock.calls[3][1])).toBe("Symbol($$nil)")
 
 		cleanUpMock, cleanUp = jest.fn()
 		setup = jest.fn()

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -223,6 +223,30 @@ describe("refs return clean up function", function()
 		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
 	end)
 
+	it("warns when a legacy detach callback returns a cleanup function", function()
+		local root = ReactNoop.createRoot()
+		local function ref(instance)
+			if instance == nil then
+				return function() end
+			end
+			return nil
+		end
+
+		ReactNoop.act(function()
+			root.render(React.createElement("div", { ref = ref }))
+		end)
+
+		jestExpect(function()
+			ReactNoop.act(function()
+				root.render(nil)
+			end)
+		end).toErrorDev(
+			"Unexpected return value from a callback ref in div. "
+				.. "A callback ref should not return a function.",
+			{ withoutStack = true }
+		)
+	end)
+
 	-- ROBLOX DEVIATION: The upstream suite exercises host refs. This parallel
 	-- public class-ref case covers React-Luau's class receiver path.
 	it("calls cleanup function for class refs", function()

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -16,6 +16,7 @@ local describe = JestGlobals.describe
 local jest = JestGlobals.jest
 local jestExpect = JestGlobals.expect
 local it = JestGlobals.it
+local Object = require(Packages.LuauPolyfill).Object
 
 local React
 local ReactNoop
@@ -63,7 +64,8 @@ describe("refs return clean up function", function()
 
 		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
 		jestExpect(setup).toHaveBeenCalledTimes(3)
-		jestExpect(setup.mock.calls[3][1]).toBe(nil)
+		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as Object.None.
+		jestExpect(setup.mock.calls[3][1]).toBe(Object.None)
 
 		cleanUpMock, cleanUp = jest.fn()
 		setup = jest.fn()

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -63,8 +63,8 @@ describe("refs return clean up function", function()
 
 		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
 		jestExpect(setup).toHaveBeenCalledTimes(3)
-		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as its nil sentinel.
-		jestExpect(tostring(setup.mock.calls[3][1])).toBe("Symbol($$nil)")
+		-- ROBLOX DEVIATION: Jest-Lua's mock matcher preserves explicit nil arguments.
+		jestExpect(setup).toHaveBeenNthCalledWith(3, nil)
 
 		cleanUpMock, cleanUp = jest.fn()
 		setup = jest.fn()

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -16,7 +16,6 @@ local describe = JestGlobals.describe
 local jest = JestGlobals.jest
 local jestExpect = JestGlobals.expect
 local it = JestGlobals.it
-local Object = require(Packages.LuauPolyfill).Object
 
 local React
 local ReactNoop
@@ -64,8 +63,9 @@ describe("refs return clean up function", function()
 
 		jestExpect(cleanUpMock).toHaveBeenCalledTimes(1)
 		jestExpect(setup).toHaveBeenCalledTimes(3)
-		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as Object.None.
-		jestExpect(setup.mock.calls[3][1]).toBe(Object.None)
+		-- ROBLOX DEVIATION: Jest-Lua records an explicit nil argument as an
+		-- Object.None sentinel owned by the mock package's dependency graph.
+		jestExpect(tostring(setup.mock.calls[3][1])).toBe("Object.None")
 
 		cleanUpMock, cleanUp = jest.fn()
 		setup = jest.fn()

--- a/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactRefCleanup.spec.lua
@@ -1,4 +1,4 @@
--- ROBLOX upstream: https://github.com/facebook/react/blob/d4e78c42a94be027b4dc7ed2659a5fddfbf9bd4e/packages/react-dom/src/__tests__/refs-test.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/d4e78c42a94be027b4dc7ed2659a5fddfbf9bd4e/packages/react-dom/src/__tests__/refs-test.js#L564-L755
 --[[*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -223,6 +223,7 @@ describe("refs return clean up function", function()
 		jestExpect(nilHandler).toHaveBeenCalledTimes(0)
 	end)
 
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/e98225485a124e35abc4cea82e6da944472ce7c7/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L304-L328
 	it("warns when a legacy detach callback returns a cleanup function", function()
 		local root = ReactNoop.createRoot()
 		local function ref(instance)
@@ -281,7 +282,7 @@ describe("refs return clean up function", function()
 	end)
 end)
 
--- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-dom/src/__tests__/refs-test.js#L785-L888
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c/packages/react-dom/src/__tests__/refs-test.js#L744-L830
 describe("useImerativeHandle refs", function()
 	beforeEach(function()
 		jest.resetModules()

--- a/modules/react-shallow-renderer/src/init.lua
+++ b/modules/react-shallow-renderer/src/init.lua
@@ -699,8 +699,20 @@ function ReactShallowRenderer:render(element, maybeContext)
 									)
 								)
 							end
+							-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react-reconciler/src/ReactFiberBeginWork.js#L397-L422
+							-- ROBLOX DEVIATION: React 19 removes react-shallow-renderer. React-Luau
+							-- still ships it, so mirror the reconciler's forwardRef compatibility path.
+							local propsWithoutRef = element.props
+							if element.props.ref ~= nil then
+								propsWithoutRef = {}
+								for key, value in element.props do
+									if key ~= "ref" then
+										propsWithoutRef[key] = value
+									end
+								end
+							end
 							self._rendered =
-								elementType.render(element.props, element.ref)
+								elementType.render(propsWithoutRef, element.props.ref)
 						else
 							self._rendered = elementType(element.props, self._context)
 						end

--- a/modules/react/src/ReactElement.lua
+++ b/modules/react/src/ReactElement.lua
@@ -38,6 +38,7 @@ local getComponentName = require(Packages.Shared).getComponentName
 -- ROBLOX deviation END
 local REACT_ELEMENT_TYPE = require(Packages.Shared).ReactSymbols.REACT_ELEMENT_TYPE
 local ReactCurrentOwner = require(Packages.Shared).ReactSharedInternals.ReactCurrentOwner
+local enableRefAsProp = require(Packages.Shared).ReactFeatureFlags.enableRefAsProp
 --local hasOwnProperty = Object.prototype.hasOwnProperty
 -- ROBLOX deviation START: upstream iterates over this table, but we manually unroll those loops for hot path performance
 -- IF THIS TABLE UPDATES, YOU MUST UPDATE THE UNROLLED LOOPS AS WELL
@@ -50,9 +51,11 @@ local RESERVED_PROPS = {
 -- ROBLOX deviation END
 
 local specialPropKeyWarningShown, specialPropRefWarningShown, didWarnAboutStringRefs
+local didWarnAboutElementRef
 
 if __DEV__ then
 	didWarnAboutStringRefs = {}
+	didWarnAboutElementRef = {}
 end
 
 local exports = {}
@@ -123,6 +126,10 @@ local function defineKeyPropWarningGetter(props, displayName: string)
 end
 
 local function defineRefPropWarningGetter(props, displayName: string)
+	if enableRefAsProp then
+		return
+	end
+
 	-- deviation: Use a __call metamethod here to make this function-like, but
 	-- still able to have the `isReactWarning` flag defined on it
 	local warnAboutAccessingRef = function()
@@ -154,6 +161,23 @@ local function defineRefPropWarningGetter(props, displayName: string)
 			return nil :: any
 		end,
 	})
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/jsx/ReactJSXElement.js#L113-L128
+local function elementRefGetterWithDeprecationWarning(element)
+	if __DEV__ then
+		local componentName = getComponentName(element.type) or "Unknown"
+		if not didWarnAboutElementRef[componentName] then
+			didWarnAboutElementRef[componentName] = true
+			console.error(
+				"Accessing element.ref was removed in React 19. ref is now a "
+					.. "regular prop. It will be removed from the JSX Element "
+					.. "type in a future release."
+			)
+		end
+
+		return element.props.ref
+	end
 end
 
 local function warnIfStringRefCannotBeAutoConverted(config)
@@ -217,15 +241,26 @@ local function ReactElement<P, T>(
 	props: P
 ): ReactElement<P, T>
 	-- ROBLOX deviation END
-	local element = {
-		-- Built-in properties that belong on the element
-		type = type_,
-		key = key,
-		ref = ref,
-		props = props,
-		-- Record the component responsible for creating this element.
-		_owner = owner,
-	}
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/jsx/ReactJSXElement.js#L150-L223
+	local resolvedRef = if enableRefAsProp then (props :: any).ref else ref
+	local element = if __DEV__ and enableRefAsProp
+		then {
+			-- Built-in properties that belong on the element
+			type = type_,
+			key = key,
+			props = props,
+			-- Record the component responsible for creating this element.
+			_owner = owner,
+		}
+		else {
+			-- Built-in properties that belong on the element
+			type = type_,
+			key = key,
+			ref = resolvedRef,
+			props = props,
+			-- Record the component responsible for creating this element.
+			_owner = owner,
+		}
 
 	-- This tag allows us to uniquely identify this as a React Element
 	element["$$typeof"] = REACT_ELEMENT_TYPE
@@ -253,13 +288,24 @@ local function ReactElement<P, T>(
 			end,
 		})
 		-- self and source are DEV only properties.
+		-- ROBLOX DEVIATION: Luau uses one __index metamethod for the non-enumerable
+		-- element.ref compatibility getter and the existing DEV-only fields.
 		setmetatable(element, {
-			__index = {
-				_self = self,
-				-- Two elements created in two different places should be considered
-				-- equal for testing purposes and therefore we hide it from enumeration.
-				_source = source,
-			},
+			__index = function(_, property)
+				if property == "ref" then
+					if resolvedRef ~= nil then
+						return elementRefGetterWithDeprecationWarning(element)
+					end
+					return nil
+				elseif property == "_self" then
+					return self
+				elseif property == "_source" then
+					-- Two elements created in two different places should be considered
+					-- equal for testing purposes and therefore we hide it from enumeration.
+					return source
+				end
+				return nil
+			end,
 		})
 	end
 
@@ -423,9 +469,14 @@ local function createElement<P, T>(
 		-- ROBLOX deviation START: inline hasValidRef and hasValidKey success in hot path, still call in error case for warning
 		-- ROBLOX FIXME Luau: needs normalization: Type 'P & React_ElementProps<T>' could not be converted into 'React_ElementProps<T>'; none of the intersection parts are compatible
 		if hasValidRef(config :: any) then
-			ref = ((config :: any) :: React_ElementProps<T>).ref
+			if not enableRefAsProp then
+				ref = ((config :: any) :: React_ElementProps<T>).ref
+			end
 
-			if __DEV__ then
+			-- ROBLOX DEVIATION: React-Luau's legacy string-ref warning is a hard
+			-- error. With ref-as-prop enabled, defer validation to the receiving
+			-- host/class component so function components can observe the prop.
+			if __DEV__ and not enableRefAsProp then
 				warnIfStringRefCannotBeAutoConverted(
 					(config :: any) :: React_ElementProps<T>
 				)
@@ -460,7 +511,7 @@ local function createElement<P, T>(
 		if props.key ~= nil then
 			props.key = nil
 		end
-		if props.ref ~= nil then
+		if not enableRefAsProp and props.ref ~= nil then
 			props.ref = nil
 		end
 		if props.__self ~= nil then
@@ -517,7 +568,7 @@ local function createElement<P, T>(
 	end
 
 	if __DEV__ then
-		if key or ref then
+		if key or (not enableRefAsProp and ref) then
 			-- ROBLOX deviation START: Lua can't store fields like displayName on functions
 			local displayName
 
@@ -539,7 +590,7 @@ local function createElement<P, T>(
 				defineKeyPropWarningGetter(props, displayName)
 			end
 
-			if ref then
+			if not enableRefAsProp and ref then
 				defineRefPropWarningGetter(props, displayName)
 			end
 		end
@@ -558,14 +609,14 @@ local function createElement<P, T>(
 
 	-- ROBLOX FIXME Luau: this cast is needed until normalization lands
 	return ReactElement(
-		type_,
-		key,
-		ref,
-		self,
-		source,
-		ReactCurrentOwner.current,
-		props
-	) :: any
+			type_,
+			key,
+			ref,
+			self,
+			source,
+			ReactCurrentOwner.current,
+			props
+		) :: any
 end
 exports.createElement = createElement
 
@@ -591,7 +642,7 @@ exports.cloneAndReplaceKey = function<P, T>(
 	local newElement = ReactElement(
 		oldElement.type,
 		newKey,
-		oldElement.ref,
+		if enableRefAsProp then nil else oldElement.ref,
 		oldElement._self,
 		oldElement._source,
 		oldElement._owner,
@@ -628,7 +679,7 @@ exports.cloneElement = function<P, T>(
 
 	-- Reserved names are extracted
 	local key = element.key
-	local ref = element.ref
+	local ref = if enableRefAsProp then nil else element.ref
 
 	-- Self is preserved since the owner is preserved.
 	-- ROBLOX deviation: _self field only used for string ref checking
@@ -646,8 +697,10 @@ exports.cloneElement = function<P, T>(
 		-- ROBLOX deviation START: inline hasValidRef and hasValidKey success in hot path, still call in error case for warning
 		local configRef = config.ref
 		if configRef ~= nil then
-			-- Silently steal the ref from the parent.
-			ref = configRef
+			if not enableRefAsProp then
+				-- Silently steal the ref from the parent.
+				ref = configRef
+			end
 			owner = ReactCurrentOwner.current
 		else
 			hasValidRef(config)
@@ -678,7 +731,13 @@ exports.cloneElement = function<P, T>(
 	-- on nil in JS, so we check for nil before iterating
 	if config ~= nil then
 		for propName, _ in config :: any do
-			if (config :: any)[propName] ~= nil and not RESERVED_PROPS[propName] then
+			if
+				(config :: any)[propName] ~= nil
+				and (
+					not RESERVED_PROPS[propName]
+					or (enableRefAsProp and propName == "ref")
+				)
+			then
 				if (config :: any)[propName] == nil and defaultProps ~= nil then
 					-- Resolve default props
 					-- ROBLOX FIXME Luau: force-cast required to avoid TypeError: Expected type table, got 'P' instead

--- a/modules/react/src/ReactElementValidator.lua
+++ b/modules/react/src/ReactElementValidator.lua
@@ -44,6 +44,7 @@ local REACT_ELEMENT_TYPE = ReactSymbols.REACT_ELEMENT_TYPE
 
 local warnAboutSpreadingKeyToJSX =
 	require(Packages.Shared).ReactFeatureFlags.warnAboutSpreadingKeyToJSX
+local enableRefAsProp = require(Packages.Shared).ReactFeatureFlags.enableRefAsProp
 local checkPropTypes = require(Packages.Shared).checkPropTypes
 local ReactCurrentOwner = require(Packages.Shared).ReactSharedInternals.ReactCurrentOwner
 
@@ -361,7 +362,8 @@ local function validateFragmentProps<P>(fragment: ReactElement<P & Object, any>)
 			end
 		end
 
-		if fragment.ref ~= nil then
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/c46fc90b670fb93e9a5558a36d0367cc735f812e/packages/react/src/jsx/ReactJSXElement.js#L1047-L1057
+		if not enableRefAsProp and fragment.ref ~= nil then
 			setCurrentlyValidatingElement(fragment)
 			console.error("Invalid attribute `ref` supplied to `React.Fragment`.")
 			setCurrentlyValidatingElement(nil)

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -259,7 +259,7 @@ exports.useMemo = useMemo
 	See [API reference for `useImperativeHandle`](https://react.dev/reference/react/useImperativeHandle).
 ]]
 local function useImperativeHandle<T>(
-	ref: { current: T | nil } | ((inst: T | nil) -> any) | nil,
+	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 	create: () -> T,
 	deps: Array<any> | nil
 ): ()

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -258,6 +258,8 @@ exports.useMemo = useMemo
 
 	See [API reference for `useImperativeHandle`](https://react.dev/reference/react/useImperativeHandle).
 ]]
+-- ROBLOX DEVIATION: Luau narrows upstream's mixed callback result to the
+-- supported cleanup function or nil.
 local function useImperativeHandle<T>(
 	ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 	create: () -> T,

--- a/modules/react/src/__tests__/ReactElement.roblox.spec.lua
+++ b/modules/react/src/__tests__/ReactElement.roblox.spec.lua
@@ -2,6 +2,7 @@
 -- ROBLOX upstream: https://github.com/facebook/react/blob/702fad4b1b48ac8f626ed3f35e8f86f5ea728084/packages/react/src/__tests__/ReactElement-test.js
 
 local Packages = script.Parent.Parent.Parent
+local React = require(script.Parent.Parent)
 local ReactElement = require(script.Parent.Parent.ReactElement)
 local JestGlobals = require(Packages.Dev.JestGlobals)
 local jestExpect = JestGlobals.expect
@@ -136,5 +137,29 @@ describe("should accept", function()
 
 		jestExpect(element).toBeDefined()
 		jestExpect(element.props.Value).toEqual(false)
+	end)
+end)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/v19.0.0/packages/react/src/__tests__/ReactCreateElement-test.js#L126-L140
+describe("ReactCreateElement", function()
+	it("does not extract ref from the rest of the props", function()
+		local ComponentClass = React.Component:extend("ComponentClass")
+		local ref = React.createRef()
+		local elementWithRef = React.createElement(ComponentClass, {
+			key = "12",
+			ref = ref,
+			foo = "56",
+		})
+
+		jestExpect(elementWithRef.type).toBe(ComponentClass)
+		jestExpect(function()
+			jestExpect(elementWithRef.ref).toBe(ref)
+		end).toErrorDev("Accessing element.ref was removed in React 19", {
+			withoutStack = true,
+		})
+		jestExpect(elementWithRef.props).toEqual({
+			foo = "56",
+			ref = ref,
+		})
 	end)
 end)

--- a/modules/shared/src/ReactFeatureFlags.lua
+++ b/modules/shared/src/ReactFeatureFlags.lua
@@ -101,6 +101,9 @@ exports.enableComponentStackLocations = true
 
 exports.enableNewReconciler = true
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/7b636d223838fd24b646ce19fece9f33b659d572/packages/shared/ReactFeatureFlags.js#L181-L187
+exports.enableRefAsProp = true
+
 -- Errors that are thrown while unmounting (or after in the case of passive effects)
 -- should bypass any error boundaries that are also unmounting (or have unmounted)
 -- and be handled by the nearest still-mounted boundary.

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -71,6 +71,8 @@ export type Dispatcher = {
 	) -> (),
 	useCallback: <T>(callback: T, deps: Array<any> | nil) -> T,
 	useMemo: <T...>(nextCreate: () -> T..., deps: Array<any> | nil) -> T...,
+	-- ROBLOX DEVIATION: Luau narrows upstream's mixed callback result to the
+	-- supported cleanup function or nil.
 	useImperativeHandle: <T>(
 		ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 		create: () -> T,

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -72,7 +72,7 @@ export type Dispatcher = {
 	useCallback: <T>(callback: T, deps: Array<any> | nil) -> T,
 	useMemo: <T...>(nextCreate: () -> T..., deps: Array<any> | nil) -> T...,
 	useImperativeHandle: <T>(
-		ref: { current: T | nil } | ((inst: T | nil) -> any) | nil,
+		ref: { current: T | nil } | ((inst: T | nil) -> (() -> ())?) | nil,
 		create: () -> T,
 		deps: Array<any> | nil
 	) -> (),

--- a/modules/shared/src/flowtypes.roblox.lua
+++ b/modules/shared/src/flowtypes.roblox.lua
@@ -216,9 +216,9 @@ export type React_ElementProps<ElementType> = {
 -- ROBLOX FIXME Luau: if I make this Object, we run into normalization issues: '{| current: React_ElementRef<any>? |}' could not be converted into '(((?) -> any) | {| current: ? |})?
 export type React_ElementRef<C> = C
 
-export type React_Ref<ElementType> =
-	{ current: React_ElementRef<ElementType> | nil }
-	| ((React_ElementRef<ElementType> | nil) -> ())
+export type React_Ref<ElementType> = { current: React_ElementRef<ElementType> | nil } | ((
+	React_ElementRef<ElementType> | nil
+) -> (() -> ())?)
 -- ROBLOX deviation: we don't support string refs, and this is unsound flowtype when used with ref param of useImperativeHandle
 -- | string
 


### PR DESCRIPTION
## Summary

Backports React 19 callback-ref cleanup functions to React-Luau. A callback ref may return a cleanup function; React calls that cleanup instead of calling the ref with nil during detachment. The same lifecycle applies to callback refs passed to useImperativeHandle.

Depends on https://github.com/Roblox/react-luau/pull/26 because this branch is stacked on the ref-as-prop backport.

## Upstream pins

- React 19.2.8: https://github.com/facebook/react/tree/1dd4ecbdabf826f527fc9a58c05ea70375b7d170
- Original callback-ref cleanup: https://github.com/facebook/react/commit/e98225485a124e35abc4cea82e6da944472ce7c7
- useImperativeHandle cleanup follow-up: https://github.com/facebook/react/commit/ed71a3ad2965617c27c6e7ca7577f15b8ca4152c
- Cleanup-versus-null regression coverage: https://github.com/facebook/react/commit/d4e78c42a94be027b4dc7ed2659a5fddfbf9bd4e

## Source and test ledger

| Upstream artifact | React-Luau destination | Disposition |
| --- | --- | --- |
| ReactFiber.new.js | ReactFiber.new.lua | Direct behavior port: store, initialize, and copy refCleanup |
| ReactFiber.old.js | None | Out of scope: this repository ships the new reconciler only |
| ReactFiberCommitWork.new.js | ReactFiberCommitWork.new.lua | Direct attach/detach port and original DEV return warning, adapted to the older split commitDetachRef path |
| ReactFiberCommitWork.old.js | None | Out of scope: old reconciler |
| ReactInternalTypes.js | ReactInternalTypes.lua | Direct Fiber and callback-ref type port |
| ReactFiberHooks.js | ReactFiberHooks.new.lua | Direct useImperativeHandle cleanup port translated to Luau |
| ReactHooks.js / ReactCurrentDispatcher.js / ReactTypes.js | ReactHooks.lua / ReactCurrentDispatcher.lua / flowtypes.roblox.lua | Public Luau callback-return types |
| ReactDOM refs-test.js | ReactRefCleanup.spec.lua | Callback-ref and imperative-handle cases in upstream order, adapted to ReactNoop |
| ReactFiberCommitWork.new.js DEV warning | ReactRefCleanup.spec.lua | Public ReactNoop coverage for a legacy detach callback returning a function |
| d4e78c42 cleanup-versus-null test | ReactRefCleanup.spec.lua | Direct behavior translation |
| DOM host renderer assertions | ReactNoop assertions | Renderer adaptation |
| DiffTrain compiled artifacts | None | Out of scope: generated build output |

One additional public class-component callback-ref parity test covers the other ref-bearing public fiber shape supported here.

## Semantics and deviations

- A returned cleanup function replaces the legacy callback(nil) detach call for that attachment.
- If a legacy detach callback itself returns a function, DEV emits the original e982254 warning. React 19.2.8 later removed this warning; this backport retains the original feature-commit contract.
- Cleanup storage is cleared on both current and alternate fibers as part of every detach, including a throwing one, preventing duplicate cleanup.
- Luau's xpcall translation clears cleanup storage before dispatching a caught error. This is mechanically equivalent to upstream's finally block and preserves at-most-once cleanup even if error dispatch throws.
- Object refs retain their existing nil-clearing behavior.
- The repository's React 17-era unguarded commitDetachRef entry point remains supported and receives equivalent cleanup semantics.
- Existing profiler behavior is preserved. The older ref-detach path remains untimed rather than importing upstream's layout-effect profiler wrapper; this deviation is recorded at the cleanup branch.
- Imperative-handle callback results are narrowed from upstream Flow's mixed result to the supported cleanup-function-or-nil shape at the Luau public and dispatcher boundaries.
- Luau nil represents the upstream null/undefined detach value.
- Suspense and Activity layout behavior are outside this standalone branch because those later reconciler backports are not present here.

## Verification

- Exact candidate commit: `7cc8646a88ba931cc4623c8e85328cfefa53bfec`
- Exact candidate tree: `653f81154b7ff72dd4a62103f500bedec837b069`
- Changed-file StyLua 0.18.1 check: passed
- Full Selene 0.28 scan: 0 errors, 0 warnings, 0 parse errors
- Rojo 7.2.1 build of tests.project.json: passed
- git diff --check: passed
- Full StyLua scan: blocked by pre-existing formatting drift in untouched files
- Hardened single-world identity smoke: 1/1 passed
- Focused DEV Studio runtime: `ReactRefCleanup.spec` 1 file, 9/9 tests passed, 0 failed, 0 skipped

Hardened harness record: `run-pr30-fd543976-hardened-final`.

| Reproducibility artifact | SHA-256 |
| --- | --- |
| Candidate archive | `F8C9AF60A04C1713708C1F97830C578904E1B5B70FCA034269FF66DB6E5CC393` |
| Rojo project | `EE9B01BA0FA76A94D8EDD2F380AA4C80393A2DA4FFE7C43A23A26B088F96B158` |
| Jest config | `DE3963AE41E1ACE7CE186070BB2C9012F2DF5072D31357BF61239C06D26D5806` |
| Focused Jest payload | `E427DD85C11491B07D5395F56C1B9ABD6E17D5C0CFD94157EAA94107243A5916` |
| Identity Jest payload | `A44BDE708B753EDF73A3F6D15DDB2A589FEC7D8CF46B94EB75289ACB8602818B` |

Generated with Codex.