### PR TITLE
Backport React 19 use API

### DIFF
--- a/docs/api-reference/react.md
+++ b/docs/api-reference/react.md
@@ -374,6 +374,35 @@ React.createElement(
 
 Hooks allow simple function components to introduce stateful behaviors without incurring the overhead or complexity of the full [Component](#reactcomponent) lifecycle.
 
+### React.use
+<a href='https://react.dev/reference/react/use' target="_blank"><img alt='React' src='../../images/reactjs.svg'/></a> <img alt='Deviation' src='../../images/deviation.svg'/>
+
+`use` reads a Context or the result of a Promise-compatible thenable. A pending
+Promise suspends the component until it settles; a rejected Promise is handled
+by the nearest error boundary. Unlike other Hooks, `use` may be called inside
+conditionals and loops.
+
+Promises passed to `use` must be created and cached outside render. React-Luau
+listens through `andThen` and stores the React `status`, `value`, and `reason`
+fields on the Promise. Roblox Promise cancellation does not notify these
+listeners, so a Promise passed to `use` must settle normally and must not be
+canceled.
+
+```lua
+local profilePromise = fetchProfile()
+
+local function Profile()
+	local profile = React.use(profilePromise)
+	return React.createElement("TextLabel", {
+		Text = profile.displayName,
+	})
+end
+```
+
+Wrap a Promise-reading component in [`React.Suspense`](#reactsuspense) and
+provide an error boundary for rejected Promises. `use` does not start requests
+or provide a data-fetching cache.
+
 ### React.useState
 <a href='https://beta.reactjs.org/reference/react/useState' target="_blank"><img alt='React' src='../../images/reactjs.svg'/></a> <img alt='API Change' src='../../images/apichange.svg'/>
 
@@ -865,4 +894,3 @@ local function Flex()
 	)
 end
 ```
-

--- a/docs/backports/react-19-use.md
+++ b/docs/backports/react-19-use.md
@@ -1,0 +1,118 @@
+# React 19 `use` backport ledger
+
+This client backport is pinned to React 19.2.0 at
+[`ae74234eae6e`](https://github.com/facebook/react/commit/ae74234eae6ebd62f19190731278e20bc1c37d51).
+It adds stable `use(Context)` and `use` for cached Promise-compatible thenables.
+It does not import React 19's server, cache, hydration, or uncached-render replay
+architecture.
+
+## Semantic history
+
+| Commit | Contract |
+| --- | --- |
+| [`b6978bc38f67`](https://github.com/facebook/react/commit/b6978bc38f6788c7e73982b9fd2771aabdf36f15) | Initial client `use(promise)`, status instrumentation, rejection, and tests |
+| [`bfb65681e7d7`](https://github.com/facebook/react/commit/bfb65681e7d77ba9bd79f7f95ac57930542b57c1) | `use(context)` |
+| [`5c43c6f02652`](https://github.com/facebook/react/commit/5c43c6f02652) | Context unwind after suspension or interruption |
+| [`d2a0176a13c9`](https://github.com/facebook/react/commit/d2a0176a13c95bd4a48cb355592db1b9105bd5d8) | Opaque suspension exception and swallowed `try/catch` warning |
+| [`1a902623a84a`](https://github.com/facebook/react/commit/1a902623a84ab004f9f042162bdcbce20f08b13f) | Synchronously resolving thenables do not suspend |
+| [`4a2d86bddbce`](https://github.com/facebook/react/commit/4a2d86bddbcef3e64bc404302cdbd9638af8801b), [`33e3d2878e9e`](https://github.com/facebook/react/commit/33e3d2878e9ec82c65468316ffcc473e5288bb87) | Preserve Hook state while replaying a suspended component |
+| [`a8f971b7a669`](https://github.com/facebook/react/commit/a8f971b7a669a9a6321b9f3cea820f68b2e4ac6e), [`adbec0c25aff`](https://github.com/facebook/react/commit/adbec0c25aff07f04b0678679554505ba2813168) | Select the correct dispatcher after replay |
+| [`7329ea81c154`](https://github.com/facebook/react/commit/7329ea81c154) | ForwardRef, memo, and legacy-context replay corrections |
+| [`18282f881dae`](https://github.com/facebook/react/commit/18282f881dae106ebf6240aa52c8c02fe7c8d6f2) | Updates while suspended are not render-phase updates |
+| [`178f4351947a`](https://github.com/facebook/react/commit/178f4351947a842ff0b56700e9115b25ae8f20d0) | Uncached client Promise warning |
+| [`7ce765ec321a`](https://github.com/facebook/react/commit/7ce765ec321a6f213019b56b36f9dccb2a8a7d5c) | Stable, unconditional public API |
+| [`7a32d718b9ea`](https://github.com/facebook/react/commit/7a32d718b9ea0eb9ea86e9d21d56a5af6c4ce9ed) | Promise inspection in React Debug Tools |
+
+The post-19.2 conditional-order warning in `cbb046ab92b` is not imported.
+
+## Source mapping
+
+| Upstream source or test | React-Luau target | Port status | Deviation |
+| --- | --- | --- | --- |
+| `packages/shared/ReactTypes.js` | `modules/shared/src/ReactTypes.lua`, `init.lua` | Ported | `andThen` replaces `then`; status fields remain optional Luau properties |
+| `packages/react/src/ReactHooks.js` | `modules/react/src/ReactHooks.lua` | Ported | None |
+| `packages/react/src/ReactClient.js`, public index exports | `modules/react/src/React.lua` | Ported | React-Luau has one public module table |
+| `packages/react-reconciler/src/ReactInternalTypes.js` | `ReactCurrentDispatcher.lua` | Ported | React-Luau duplicates the dispatcher type in Shared |
+| `packages/shared/ReactSymbols.js` | Existing `ReactSymbols.lua` | Reused | Existing `REACT_CONTEXT_TYPE` identifies Context values |
+| `packages/react-reconciler/src/ReactFiberHooks.js` | `ReactFiberHooks.new.lua` | Adapted | `use` allocates no Hook node; all dispatcher variants expose it; one-based thenable positions; full React 19 replay is excluded |
+| `packages/react-reconciler/src/ReactFiberThenable.js` | New `ReactFiberThenable.lua` | Adapted | Cached client thenables, `andThen`, one-based positions, no async debug metadata, act accounting, Actions, or commit resources |
+| `packages/react-reconciler/src/ReactFiberWorkLoop.js` | `ReactFiberWorkLoop.new.lua` | Adapted | Opaque sentinel is converted before React 17's existing unwind path; there is no `SuspendedOnImmediate` replay state |
+| `packages/react-reconciler/src/ReactFiberThrow.js` | Existing `ReactFiberThrow.new.lua` | Reused | Existing `andThen` wakeable capture, ping listener, and retry path needs no change |
+| `packages/react-reconciler/src/ReactFiberNewContext.js` | Existing `ReactFiberNewContext.new.lua` | Reused | Existing context dependency and unwind behavior is sufficient |
+| `ReactFiber.js`, `ReactInternalTypes.js` DEV thenable state | No target | Excluded | Fiber-retained uncached thenable replay and committed thenable substitution are outside the cached-client boundary |
+| `packages/react/src/ReactAct.js` | No target | Excluded | React-Luau's act implementation has no React 19 `didUsePromise` microtask protocol |
+| `packages/react-debug-tools/src/ReactDebugHooks.js` | `modules/react-debug-tools/src/ReactDebugHooks.lua` | Adapted | Inspects Context and cached fulfilled/rejected thenables directly; unresolved inspection returns a partial tree |
+| React shallow renderer dispatcher | `modules/react-shallow-renderer/src/init.lua` | React-Luau-only adaptation | A pending thenable is rethrown directly because this renderer has no Suspense work loop |
+
+`ReactFiberThenable.useThenable` and suspended-thenable retrieval are generic
+reconciler seams. A later Actions backport consumes them and adds only its
+action-specific suspension exception and scheduling behavior.
+
+## Test mapping
+
+The primary upstream suite is
+[`ReactUse-test.js`](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactUse-test.js).
+
+| Upstream test | Port status | React-Luau coverage or reason |
+| --- | --- | --- |
+| `basic use(promise)` | Ported | Multiple cached fulfilled thenables |
+| Pending Promise fallback, ping, resolve, and retry behavior | Ported | Custom thenable and real Roblox Promise cases |
+| `using a promise that's not cached between attempts` | Excluded | Requires retained thenable state plus immediate component replay; callers must cache outside render |
+| `using a rejected promise will throw` | Ported | Pre-rejected and pending-then-rejected paths reach an Error Boundary |
+| `use(promise) in multiple components` | Ported | Parent and child read independent cached thenables |
+| `use(promise) in multiple sibling components` | Covered by the same substrate | Per-component state resets on every successful render and unwind; sibling-prewarming ordering is excluded |
+| `erroring in the same component as an uncached promise does not result in an infinite loop` | Excluded | Uncached render-created Promises are unsupported |
+| `basic use(context)` | Ported | Provider and default Context values |
+| `interrupting while yielded should reset contexts` | Covered by existing Context unwind | Its upstream fixture depends on React 19 lazy/renderable-node behavior outside this port |
+| `warns if use(promise) is wrapped with try/catch block` | Ported | Identity-stable opaque exception and DEV warning |
+| `unwraps thenable that fulfills synchronously without suspending` | Ported | Custom synchronous `andThen` fixture |
+| `does not suspend indefinitely if an interleaved update was skipped` | Excluded | Depends on React 19 immediate replay and lane behavior |
+| `load multiple nested Suspense boundaries` | Covered by existing Suspense tests | React 19 sibling prewarming and log ordering are excluded |
+| `use() combined with render phase updates` | Adapted | Cached, already-fulfilled resources prove stale positions are discarded before rerender |
+| Uncached ForwardRef, memo, and legacy-context cases | Excluded | Uncached replay architecture is outside scope; public `use` still works inside these component types with cached inputs |
+| `updates while component is suspended should not be mistaken for render phase updates` | Excluded | React 19 replay/lane regression |
+| Both `does not get stuck in pending state after use suspends` cases | Excluded | React 19 replay and transition scheduling regressions |
+| Conditional and looped `use` calls | Ported | `use` never enters Hook type/order tracking and may precede a stateful Hook |
+| Unsupported input | Ported in runtime | Throws the upstream unsupported-type error |
+
+The `ReactUse-test.js` cases gated by `enableSuspendingDuringWorkLoop` are
+inactive in React 19.2 and remain excluded. They exercise async Client
+Components, generators, and async iterables.
+
+| Other upstream suite | Port status | Coverage or reason |
+| --- | --- | --- |
+| `ReactHooksInspection-test.js`: Promise, Context, unresolved, anonymous loop | Ported/adapted | Direct inspection covers Promise, Context, and unresolved values; reconciler tests cover loop semantics |
+| `ReactHooksInspectionIntegration-test.js`: `use(Context)` | Ported | Committed Fiber inspection covers cached Promise, Context, and following stateful Hook IDs |
+| Committed `_debugThenableState` substitution | Excluded | No direct React 19.2 test; requires Fiber-retained replay state |
+| `ReactIsomorphicAct-test.js` Promise microtask cases | Excluded | React-Luau uses its existing Promise-aware act implementation rather than React 19's `didUsePromise` protocol |
+| Shallow renderer fulfilled/rejected/context behavior | Added | React-Luau compatibility coverage; no equivalent upstream renderer path |
+
+## Runtime contract
+
+- A Promise passed to `use` is created and cached outside render.
+- A cached Promise must settle normally. Roblox Promise cancellation does not
+  notify ordinary `andThen` listeners and is unsupported for this API.
+- `use` is not a request launcher, cache, or data-fetching framework.
+- Pending reads require a Suspense boundary; rejected reads require an Error
+  Boundary.
+- `use(Context)` and cached thenable reads may appear in conditions and loops.
+- A thenable is unwrapped exactly once.
+
+## Exclusions
+
+- RSC/Flight hooks, serialization, task replay, and server resources
+- Fizz/SSR and hydration or selective hydration
+- `cache`, `cacheSignal`, `useCacheRefresh`, Cache components, and pooled caches
+- Promise or Context values rendered as children
+- Async components, generators, and async iterables
+- Sibling prewarming and prerender lane behavior
+- Actions, `useActionState`, `useOptimistic`, and `SuspenseActionException`
+- Commit resources and lazy/resource suspension sentinels unrelated to public
+  `use`
+- JavaScript async-function detection and React 19 async debug metadata
+
+Full uncached-Promise fidelity would additionally require
+`ReactFiberBeginWork.new.lua`, split throw/unwind Hook resets, suspended reason
+and replay machinery in `ReactFiberWorkLoop.new.lua`, Fiber dependency cloning,
+and DEV `_debugThenableState`. That expansion is intentionally not part of this
+backport.

--- a/docs/backports/react-19-use.md
+++ b/docs/backports/react-19-use.md
@@ -34,8 +34,8 @@ The post-19.2 conditional-order warning in `cbb046ab92b` is not imported.
 | `packages/react/src/ReactClient.js`, public index exports | `modules/react/src/React.lua` | Ported | React-Luau has one public module table |
 | `packages/react-reconciler/src/ReactInternalTypes.js` | `ReactCurrentDispatcher.lua` | Ported | React-Luau duplicates the dispatcher type in Shared |
 | `packages/shared/ReactSymbols.js` | Existing `ReactSymbols.lua` | Reused | Existing `REACT_CONTEXT_TYPE` identifies Context values |
-| `packages/react-reconciler/src/ReactFiberHooks.js` | `ReactFiberHooks.new.lua` | Adapted | `use` allocates no Hook node; all dispatcher variants expose it; one-based thenable positions; full React 19 replay is excluded |
-| `packages/react-reconciler/src/ReactFiberThenable.js` | New `ReactFiberThenable.lua` | Adapted | Cached client thenables, `andThen`, one-based positions, no async debug metadata, act accounting, Actions, or commit resources |
+| `packages/react-reconciler/src/ReactFiberHooks.js` | `ReactFiberHooks.new.lua`, `ReactFiberThenable.lua` | Adapted | `use` allocates no Hook node; all dispatcher variants expose it; one-based thenable positions; React 17 has no replay dispatcher, so the post-`use` dispatcher switch is omitted |
+| `packages/react-reconciler/src/ReactFiberThenable.js` | New `ReactFiberThenable.lua` | Adapted | Cached client thenables and `andThen`; non-`nil` custom statuses replace the upstream string check; async-catch detection and retained uncached-Promise warnings are absent; without the infinite-ping guard, an uncached self-resolving Promise silently retries instead of throwing React 19's error; async debug metadata, act accounting, Actions, and commit resources are absent |
 | `packages/react-reconciler/src/ReactFiberWorkLoop.js` | `ReactFiberWorkLoop.new.lua` | Adapted | Opaque sentinel is converted before React 17's existing unwind path; there is no `SuspendedOnImmediate` replay state |
 | `packages/react-reconciler/src/ReactFiberThrow.js` | Existing `ReactFiberThrow.new.lua` | Reused | Existing `andThen` wakeable capture, ping listener, and retry path needs no change |
 | `packages/react-reconciler/src/ReactFiberNewContext.js` | Existing `ReactFiberNewContext.new.lua` | Reused | Existing context dependency and unwind behavior is sufficient |
@@ -55,16 +55,19 @@ The primary upstream suite is
 
 | Upstream test | Port status | React-Luau coverage or reason |
 | --- | --- | --- |
-| `basic use(promise)` | Ported | Multiple cached fulfilled thenables |
+| `does not infinite loop if already fulfilled thenable is thrown` | Adapted | Direct port; React 17 has no sibling prewarming, so it performs one suspension attempt before the fallback |
+| `basic use(promise)` | Adapted | Multiple cached, pre-instrumented fulfilled thenables preserve positional reads without importing transition replay |
 | Pending Promise fallback, ping, resolve, and retry behavior | Ported | Custom thenable and real Roblox Promise cases |
 | `using a promise that's not cached between attempts` | Excluded | Requires retained thenable state plus immediate component replay; callers must cache outside render |
 | `using a rejected promise will throw` | Ported | Pre-rejected and pending-then-rejected paths reach an Error Boundary |
-| `use(promise) in multiple components` | Ported | Parent and child read independent cached thenables |
+| `use(promise) in multiple components` | Adapted | The renamed parent/child case reads independent pre-instrumented fulfilled thenables and preserves the upstream yield assertion |
 | `use(promise) in multiple sibling components` | Covered by the same substrate | Per-component state resets on every successful render and unwind; sibling-prewarming ordering is excluded |
 | `erroring in the same component as an uncached promise does not result in an infinite loop` | Excluded | Uncached render-created Promises are unsupported |
 | `basic use(context)` | Ported | Provider and default Context values |
 | `interrupting while yielded should reset contexts` | Covered by existing Context unwind | Its upstream fixture depends on React 19 lazy/renderable-node behavior outside this port |
 | `warns if use(promise) is wrapped with try/catch block` | Ported | Identity-stable opaque exception and DEV warning |
+| `when waiting for data to resolve, a fresh update will trigger a restart` | Excluded | Gated off at the React 19.2 pin and depends on work-loop suspension during transitions |
+| `when waiting for data to resolve, an update on a different root does not cause work to be dropped` | Excluded | Gated off at the React 19.2 pin and depends on work-loop suspension during transitions |
 | `unwraps thenable that fulfills synchronously without suspending` | Ported | Custom synchronous `andThen` fixture |
 | `does not suspend indefinitely if an interleaved update was skipped` | Excluded | Depends on React 19 immediate replay and lane behavior |
 | `load multiple nested Suspense boundaries` | Covered by existing Suspense tests | React 19 sibling prewarming and log ordering are excluded |

--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -43,6 +43,7 @@ type MutableSourceSubscribeFn<Source, Snapshot> = ReactTypes.MutableSourceSubscr
 >
 type ReactContext<T> = ReactTypes.ReactContext<T>
 type ReactProviderType<T> = ReactTypes.ReactProviderType<T>
+type Usable<T> = ReactTypes.Usable<T>
 
 -- ROBLOX deviation END
 -- ROBLOX deviation START: add import type that is a built-in in flow
@@ -102,7 +103,9 @@ local ErrorStackParser = {
 local SharedModule = require(Packages.Shared)
 local ReactSharedInternals = SharedModule.ReactSharedInternals
 local ReactSymbols = SharedModule.ReactSymbols
+local REACT_CONTEXT_TYPE = ReactSymbols.REACT_CONTEXT_TYPE
 local REACT_OPAQUE_ID_TYPE = ReactSymbols.REACT_OPAQUE_ID_TYPE
+local SuspenseException = Error.new("Suspended while inspecting a pending Promise")
 -- ROBLOX deviation END
 -- ROBLOX deviation START: fix import - get from ReconcilerModule
 -- local reactReconcilerSrcReactWorkTagsModule =
@@ -177,6 +180,18 @@ local function getPrimitiveStackCache(): Map<string, Array<any>>
 					-- ROBLOX deviation END
 					return nil
 				end)
+				Dispatcher.use({
+					["$$typeof"] = REACT_CONTEXT_TYPE,
+					_currentValue = nil,
+				} :: any)
+				Dispatcher.use({
+					andThen = function() end,
+					status = "fulfilled",
+					value = nil,
+				} :: any)
+				pcall(function()
+					Dispatcher.use({ andThen = function() end } :: any)
+				end)
 			end)
 			do
 				readHookLog = hookLog
@@ -232,6 +247,45 @@ local function readContext<T>(
 	-- For now we don't expose readContext usage in the hooks debugging info.
 	return context._currentValue
 end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-debug-tools/src/ReactDebugHooks.js#L182-L237
+-- ROBLOX DEVIATION: Cached Promise inspection reads the instrumented Promise
+-- directly because this fork does not retain uncached thenables after unwind.
+local function use<T>(usable: Usable<T>): T
+	if usable ~= nil and typeof(usable) == "table" then
+		if typeof((usable :: any).andThen) == "function" then
+			if (usable :: any).status == "fulfilled" then
+				local value = (usable :: any).value :: T
+				table.insert(hookLog, {
+					primitive = "Promise",
+					stackError = Error.new(),
+					value = value,
+				})
+				return value
+			elseif (usable :: any).status == "rejected" then
+				error((usable :: any).reason)
+			end
+
+			table.insert(hookLog, {
+				primitive = "Unresolved",
+				stackError = Error.new(),
+				value = usable,
+			})
+			error(SuspenseException)
+		elseif (usable :: any)["$$typeof"] == REACT_CONTEXT_TYPE then
+			local value = readContext(usable :: ReactContext<T>, nil)
+			table.insert(hookLog, {
+				primitive = "Context (use)",
+				stackError = Error.new(),
+				value = value,
+			})
+			return value
+		end
+	end
+
+	error(Error.new("An unsupported type was passed to use(): " .. tostring(usable)))
+end
+
 local function useContext<T>(
 	context: ReactContext<T>,
 	observedBits: void | number | boolean
@@ -509,6 +563,7 @@ end
 Dispatcher = {
 	-- ROBLOX deviation END
 	readContext = readContext,
+	use = use,
 	useCallback = useCallback,
 	useContext = useContext,
 	useEffect = useEffect,
@@ -648,7 +703,11 @@ local function isReactWrapper(functionName, primitiveName)
 		-- ROBLOX deviation END
 		return false
 	end
-	local expectedPrimitiveName = "use" .. tostring(primitiveName)
+	local expectedPrimitiveName = if primitiveName == "Context (use)"
+			or primitiveName == "Promise"
+			or primitiveName == "Unresolved"
+		then "use"
+		else "use" .. tostring(primitiveName)
 	-- ROBLOX deviation START: fix length implementation + Luau doesn't understand the guard above
 	-- if
 	-- 	functionName.length
@@ -941,7 +1000,11 @@ local function buildTree(rootStack, readHookLog: Array<any>): HooksTree
 		-- For now, the "id" of stateful hooks is just the stateful hook index.
 		-- Custom hooks have no ids, nor do non-stateful native hooks (e.g. Context, DebugValue).
 		-- ROBLOX FIXME Luau: Luau doesn't infer number | nil like it should
-		local id = if primitive == "Context" or primitive == "DebugValue"
+		local id = if primitive == "Context"
+				or primitive == "Context (use)"
+				or primitive == "DebugValue"
+				or primitive == "Promise"
+				or primitive == "Unresolved"
 			then nil
 			else POSTFIX_INCREMENT()
 		-- For the time being, only State and Reducer hooks support runtime overrides.
@@ -1067,7 +1130,7 @@ local function inspectHooks<Props>(
 		-- 	return result
 		-- end
 		-- ROBLOX deviation END
-		if not ok then
+		if not ok and result ~= SuspenseException then
 			error(result)
 		end
 	end
@@ -1142,7 +1205,7 @@ local function inspectHooksOfForwardRef<Props, Ref>(
 		-- 	return result
 		-- end
 		-- ROBLOX deviation END
-		if not ok then
+		if not ok and result ~= SuspenseException then
 			error(result)
 		end
 	end

--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -248,7 +248,7 @@ local function readContext<T>(
 	return context._currentValue
 end
 
--- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-debug-tools/src/ReactDebugHooks.js#L182-L237
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-debug-tools/src/ReactDebugHooks.js#L192-L265
 -- ROBLOX DEVIATION: Cached Promise inspection reads the instrumented Promise
 -- directly because this fork does not retain uncached thenables after unwind.
 local function use<T>(usable: Usable<T>): T

--- a/modules/react-debug-tools/src/__tests__/ReactHooksInspection.spec.lua
+++ b/modules/react-debug-tools/src/__tests__/ReactHooksInspection.spec.lua
@@ -342,6 +342,67 @@ describe("ReactHooksInspection", function()
 			},
 		})
 	end)
+	it("should inspect a fulfilled promise read with use", function()
+		local promise = {
+			andThen = function() end,
+			status = "fulfilled",
+			value = "resolved",
+		}
+		local function Foo()
+			React.use(promise)
+			return nil
+		end
+
+		local tree = ReactDebugTools.inspectHooks(Foo, {})
+
+		expect(tree).toEqual({
+			{
+				isStateEditable = false,
+				id = nil,
+				name = "Promise",
+				value = "resolved",
+				subHooks = {},
+			},
+		})
+	end)
+	it("should inspect a context read with use", function()
+		local MyContext = React.createContext("default")
+		local function Foo()
+			React.use(MyContext)
+			return nil
+		end
+
+		local tree = ReactDebugTools.inspectHooks(Foo, {})
+
+		expect(tree).toEqual({
+			{
+				isStateEditable = false,
+				id = nil,
+				name = "Context (use)",
+				value = "default",
+				subHooks = {},
+			},
+		})
+	end)
+	it("should report an unresolved promise read with use", function()
+		local promise = { andThen = function() end }
+		local function Foo()
+			React.use(promise)
+			return nil
+		end
+
+		local tree = ReactDebugTools.inspectHooks(Foo, {})
+
+		expect(tree).toEqual({
+			{
+				isStateEditable = false,
+				id = nil,
+				name = "Unresolved",
+				value = promise,
+				subHooks = {},
+			},
+		})
+	end)
 	it("should support an injected dispatcher", function()
 		local function Foo(props)
 			-- ROBLOX deviation START: useState returns 2 values

--- a/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
+++ b/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
@@ -168,6 +168,48 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end)
+	it("should inspect committed use calls for Promise and Context", function()
+		local promise = {
+			andThen = function() end,
+			status = "fulfilled",
+			value = "resolved",
+		}
+		local Context = React.createContext("context")
+		local function Foo()
+			React.use(promise)
+			React.use(Context)
+			React.useState("state")
+			return React.createElement("Frame")
+		end
+
+		local renderer = ReactTestRenderer.create(React.createElement(Foo))
+		local childFiber = renderer.root:findByType(Foo):_currentFiber()
+		local tree = ReactDebugTools.inspectHooksOfFiber(childFiber)
+
+		expect(tree).toEqual({
+			{
+				isStateEditable = false,
+				id = nil :: number | nil,
+				name = "Promise",
+				value = "resolved" :: any,
+				subHooks = {},
+			},
+			{
+				isStateEditable = false,
+				id = nil :: number | nil,
+				name = "Context (use)",
+				value = "context" :: any,
+				subHooks = {},
+			},
+			{
+				isStateEditable = true,
+				id = 1,
+				name = "State",
+				value = "state",
+				subHooks = {},
+			},
+		})
+	end)
 	it("should inspect the current state of all stateful hooks", function()
 		local outsideRef = React.createRef()
 		local function effect() end

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -33,6 +33,8 @@ local console = require(Packages.Shared).console
 
 local ReactTypes = require(Packages.Shared)
 type ReactContext<T> = ReactTypes.ReactContext<T>
+type Thenable<T> = ReactTypes.Thenable<T>
+type Usable<T> = ReactTypes.Usable<T>
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
 type MutableSource<T> = ReactTypes.MutableSource<T>
@@ -151,6 +153,9 @@ local markStateUpdateScheduled =
 local ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher
 -- local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
+local REACT_CONTEXT_TYPE = require(Packages.Shared).ReactSymbols.REACT_CONTEXT_TYPE
+local ReactFiberThenable = require(script.Parent.ReactFiberThenable)
+
 local FFlagReactCleanQueueOnUpdateBailout =
 	require(Packages.SafeFlags).createGetFFlag("ReactCleanQueueOnUpdateBailout")()
 
@@ -174,10 +179,12 @@ type UpdateQueue<S, A> = {
 }
 
 local didWarnAboutMismatchedHooksForComponent
+local didWarnAboutUseWrappedInTryCatch
 local _didWarnAboutUseOpaqueIdentifier
 if __DEV__ then
 	_didWarnAboutUseOpaqueIdentifier = {}
 	didWarnAboutMismatchedHooksForComponent = {}
+	didWarnAboutUseWrappedInTryCatch = {}
 end
 
 export type Hook = {
@@ -525,6 +532,11 @@ exports.resetHooksAfterThrow = function(): ()
 	end
 
 	didScheduleRenderPhaseUpdateDuringThisPass = false
+	-- ROBLOX DEVIATION: React 17's work loop always unwinds a suspended
+	-- component instead of replaying it in place. Clear positional thenable
+	-- state on unwind; callers must pass a stable cached Promise so its
+	-- instrumented status survives the retry.
+	ReactFiberThenable.resetThenableState()
 end
 
 local function mountWorkInProgressHook(): Hook
@@ -1925,10 +1937,24 @@ function dispatchAction<S, A>(fiber: Fiber, queue: UpdateQueue<S, A>, action: A,
 	return
 end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L1151-L1166
+local function use<T>(usable: Usable<T>): T
+	if usable ~= nil and typeof(usable) == "table" then
+		if typeof((usable :: any).andThen) == "function" then
+			return ReactFiberThenable.useThenable(usable :: Thenable<T>)
+		elseif (usable :: any)["$$typeof"] == REACT_CONTEXT_TYPE then
+			return readContext(usable :: ReactContext<T>, nil)
+		end
+	end
+
+	error(Error.new("An unsupported type was passed to use(): " .. tostring(usable)))
+end
+
 -- deviation: Move these to the top so they're in scope for above functions
 local ContextOnlyDispatcher: Dispatcher = {
 	readContext = readContext,
 
+	use = use,
 	useCallback = throwInvalidHookError :: any,
 	useContext = throwInvalidHookError :: any,
 	useEffect = throwInvalidHookError :: any,
@@ -1952,6 +1978,7 @@ exports.ContextOnlyDispatcher = ContextOnlyDispatcher
 local HooksDispatcherOnMount: Dispatcher = {
 	readContext = readContext,
 
+	use = use,
 	useCallback = mountCallback,
 	useContext = readContext,
 	useEffect = mountEffect,
@@ -1975,6 +2002,7 @@ local HooksDispatcherOnMount: Dispatcher = {
 local HooksDispatcherOnUpdate: Dispatcher = {
 	readContext = readContext,
 
+	use = use,
 	useCallback = updateCallback,
 	useContext = readContext,
 	useEffect = updateEffect,
@@ -1998,6 +2026,7 @@ local HooksDispatcherOnUpdate: Dispatcher = {
 local HooksDispatcherOnRerender: Dispatcher = {
 	readContext = readContext,
 
+	use = use,
 	useCallback = updateCallback,
 	useContext = readContext,
 	useEffect = updateEffect,
@@ -2044,6 +2073,7 @@ if __DEV__ then
 		): T
 			return readContext(context, observedBits)
 		end,
+		use = use,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
 			mountHookTypesDev()
@@ -2198,6 +2228,7 @@ if __DEV__ then
 		): T
 			return readContext(context, observedBits)
 		end,
+		use = use,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
 			updateHookTypesDev()
@@ -2347,6 +2378,7 @@ if __DEV__ then
 		): T
 			return readContext(context, observedBits)
 		end,
+		use = use,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
 			updateHookTypesDev()
@@ -2495,6 +2527,7 @@ if __DEV__ then
 		): T
 			return readContext(context, observedBits)
 		end,
+		use = use,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
 			updateHookTypesDev()
@@ -2644,6 +2677,10 @@ if __DEV__ then
 		): T
 			warnInvalidContextAccess()
 			return readContext(context, observedBits)
+		end,
+		use = function<T>(usable: Usable<T>): T
+			warnInvalidHookAccess()
+			return use(usable)
 		end,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
@@ -2809,6 +2846,10 @@ if __DEV__ then
 			warnInvalidContextAccess()
 			return readContext(context, observedBits)
 		end,
+		use = function<T>(usable: Usable<T>): T
+			warnInvalidHookAccess()
+			return use(usable)
+		end,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
 			warnInvalidHookAccess()
@@ -2973,6 +3014,10 @@ if __DEV__ then
 		): T
 			warnInvalidContextAccess()
 			return readContext(context, observedBits)
+		end,
+		use = function<T>(usable: Usable<T>): T
+			warnInvalidHookAccess()
+			return use(usable)
 		end,
 		useCallback = function<T>(callback: T, deps: Array<any> | nil): T
 			currentHookNameInDev = "useCallback"
@@ -3202,6 +3247,7 @@ local function renderWithHooks<Props, SecondArg>(
 		local numberOfReRenders: number = 0
 		repeat
 			didScheduleRenderPhaseUpdateDuringThisPass = false
+			ReactFiberThenable.resetThenableState()
 			-- ROBLOX performance: use React 18 approach to avoid invariant in hot path
 			if numberOfReRenders >= RE_RENDER_LIMIT then
 				error(
@@ -3264,6 +3310,19 @@ local function renderWithHooks<Props, SecondArg>(
 	end
 
 	didScheduleRenderPhaseUpdate = false
+	ReactFiberThenable.resetThenableState()
+
+	if __DEV__ and ReactFiberThenable.checkIfUseWrappedInTryCatch() then
+		local componentName = getComponentName(workInProgress.type) or "Unknown"
+		if not didWarnAboutUseWrappedInTryCatch[componentName] then
+			didWarnAboutUseWrappedInTryCatch[componentName] = true
+			console.error(
+				"`use` was called from inside a try/catch block. This is not allowed "
+					.. "and can lead to unexpected behavior. To handle errors triggered "
+					.. "by `use`, wrap your component in a error boundary."
+			)
+		end
+	end
 
 	-- ROBLOX performance: use React 18 approach that avoid invariant in hot paths
 	if didRenderTooFewHooks then

--- a/modules/react-reconciler/src/ReactFiberThenable.lua
+++ b/modules/react-reconciler/src/ReactFiberThenable.lua
@@ -58,6 +58,13 @@ local thenableState: ThenableState? = nil
 -- features and are not part of this cached client Promise backport.
 -- Roblox Promise cancellation does not notify ordinary `andThen` listeners,
 -- so a Promise passed to use must settle normally and must not be canceled.
+-- `status ~= nil` is broader than upstream's string-only custom status check;
+-- the Luau Thenable type only admits string states. Async Client Components
+-- are excluded, so rejected reasons omit `checkIfUseWrappedInAsyncCatch`.
+-- Without Fiber-retained replay state, the uncached-Promise warning cannot see
+-- replacements between attempts. React 17 also has no shell suspend counter,
+-- so an uncached self-resolving Promise silently retries instead of reaching
+-- React 19's infinite-ping error.
 local function trackUsedThenable<T>(
 	thenableState: ThenableState,
 	thenable: Thenable<T>,
@@ -114,9 +121,12 @@ local function trackUsedThenable<T>(
 	error(SuspenseException)
 end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L1095-L1149
 -- ROBLOX DEVIATION: Keep the per-component counters in this module because
 -- ReactFiberHooks.new.lua is at Luau's local-register limit. Luau arrays are
--- one-indexed, so the first thenable occupies slot 1 instead of slot 0.
+-- one-indexed, so the first thenable occupies slot 1 instead of slot 0. React
+-- 17 has no suspended-component replay dispatcher, so the post-use switch back
+-- to a mount or update dispatcher is omitted.
 local function useThenable<T>(thenable: Thenable<T>): T
 	local index = thenableIndexCounter
 	thenableIndexCounter += 1

--- a/modules/react-reconciler/src/ReactFiberThenable.lua
+++ b/modules/react-reconciler/src/ReactFiberThenable.lua
@@ -18,13 +18,24 @@ type Thenable<T> = ReactTypes.Thenable<T>
 local __DEV__ = ReactGlobals.__DEV__
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L31-L49
--- ROBLOX DEVIATION: This client-only port always uses the development object
--- shape. The production array shape is an allocation optimization rather than
--- a behavior difference.
-export type ThenableState = {
+type ThenableStateDev = {
 	didWarnAboutUncachedPromise: boolean,
 	thenables: { Thenable<any> },
 }
+
+type ThenableStateProd = { Thenable<any> }
+
+export type ThenableState = ThenableStateDev | ThenableStateProd
+
+local function getThenablesFromState(state: ThenableState): { Thenable<any> }
+	if __DEV__ then
+		local devState = (state :: any) :: ThenableStateDev
+		return devState.thenables
+	else
+		local prodState = (state :: any) :: ThenableStateProd
+		return prodState
+	end
+end
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L51-L61
 local SuspenseException = Error.new(
@@ -39,11 +50,16 @@ local SuspenseException = Error.new(
 
 local function noop() end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L89-L102
 local function createThenableState(): ThenableState
-	return {
-		didWarnAboutUncachedPromise = false,
-		thenables = {},
-	}
+	if __DEV__ then
+		return {
+			didWarnAboutUncachedPromise = false,
+			thenables = {},
+		}
+	else
+		return {}
+	end
 end
 
 local suspendedThenable: Thenable<any>? = nil
@@ -70,17 +86,21 @@ local function trackUsedThenable<T>(
 	thenable: Thenable<T>,
 	index: number
 ): T
-	local previous = thenableState.thenables[index]
+	local trackedThenables = getThenablesFromState(thenableState)
+	local previous = trackedThenables[index]
 	if previous == nil then
-		thenableState.thenables[index] = thenable
+		trackedThenables[index] = thenable
 	elseif previous ~= thenable then
-		if __DEV__ and not thenableState.didWarnAboutUncachedPromise then
-			thenableState.didWarnAboutUncachedPromise = true
-			console.error(
-				"A component was suspended by an uncached promise. Creating "
-					.. "promises inside a Client Component or hook is not yet "
-					.. "supported, except via a Suspense-compatible library or framework."
-			)
+		if __DEV__ then
+			local thenableStateDev = (thenableState :: any) :: ThenableStateDev
+			if not thenableStateDev.didWarnAboutUncachedPromise then
+				thenableStateDev.didWarnAboutUncachedPromise = true
+				console.error(
+					"A component was suspended by an uncached promise. Creating "
+						.. "promises inside a Client Component or hook is not yet "
+						.. "supported, except via a Suspense-compatible library or framework."
+				)
+			end
 		end
 
 		thenable:andThen(noop, noop)

--- a/modules/react-reconciler/src/ReactFiberThenable.lua
+++ b/modules/react-reconciler/src/ReactFiberThenable.lua
@@ -1,0 +1,168 @@
+--!strict
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+]]
+
+local Packages = script.Parent.Parent
+local ReactGlobals = require(Packages.ReactGlobals)
+local Error = require(Packages.LuauPolyfill).Error
+local console = require(Packages.Shared).console
+local ReactTypes = require(Packages.Shared)
+type Thenable<T> = ReactTypes.Thenable<T>
+
+local __DEV__ = ReactGlobals.__DEV__
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L31-L49
+-- ROBLOX DEVIATION: This client-only port always uses the development object
+-- shape. The production array shape is an allocation optimization rather than
+-- a behavior difference.
+export type ThenableState = {
+	didWarnAboutUncachedPromise: boolean,
+	thenables: { Thenable<any> },
+}
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L51-L61
+local SuspenseException = Error.new(
+	"Suspense Exception: This is not a real error! It's an implementation "
+		.. "detail of `use` to interrupt the current render. You must either "
+		.. "rethrow it immediately, or move the `use` call outside of the "
+		.. "`try/catch` block. Capturing without rethrowing will lead to "
+		.. "unexpected behavior.\n\n"
+		.. "To handle async errors, wrap your component in an error boundary, or "
+		.. "call the promise's `.catch` method and pass the result to `use`."
+)
+
+local function noop() end
+
+local function createThenableState(): ThenableState
+	return {
+		didWarnAboutUncachedPromise = false,
+		thenables = {},
+	}
+end
+
+local suspendedThenable: Thenable<any>? = nil
+local needsToResetSuspendedThenableDEV = false
+local thenableIndexCounter = 1
+local thenableState: ThenableState? = nil
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L107-L289
+-- ROBLOX DEVIATION: Roblox Promise-compatible thenables expose `andThen`.
+-- Async debug information, act microtask accounting, async Client Component
+-- loop detection, Actions, and commit-suspension resources are separate
+-- features and are not part of this cached client Promise backport.
+-- Roblox Promise cancellation does not notify ordinary `andThen` listeners,
+-- so a Promise passed to use must settle normally and must not be canceled.
+local function trackUsedThenable<T>(
+	thenableState: ThenableState,
+	thenable: Thenable<T>,
+	index: number
+): T
+	local previous = thenableState.thenables[index]
+	if previous == nil then
+		thenableState.thenables[index] = thenable
+	elseif previous ~= thenable then
+		if __DEV__ and not thenableState.didWarnAboutUncachedPromise then
+			thenableState.didWarnAboutUncachedPromise = true
+			console.error(
+				"A component was suspended by an uncached promise. Creating "
+					.. "promises inside a Client Component or hook is not yet "
+					.. "supported, except via a Suspense-compatible library or framework."
+			)
+		end
+
+		thenable:andThen(noop, noop)
+		thenable = previous :: Thenable<T>
+	end
+
+	if thenable.status == "fulfilled" then
+		return thenable.value :: T
+	elseif thenable.status == "rejected" then
+		error(thenable.reason)
+	elseif thenable.status ~= nil then
+		thenable:andThen(noop, noop)
+	else
+		thenable.status = "pending"
+		thenable:andThen(function(value: T)
+			if thenable.status == "pending" then
+				thenable.status = "fulfilled"
+				thenable.value = value
+			end
+		end, function(reason: any)
+			if thenable.status == "pending" then
+				thenable.status = "rejected"
+				thenable.reason = reason
+			end
+		end)
+	end
+
+	if thenable.status == "fulfilled" then
+		return thenable.value :: T
+	elseif thenable.status == "rejected" then
+		error(thenable.reason)
+	end
+
+	suspendedThenable = thenable
+	if __DEV__ then
+		needsToResetSuspendedThenableDEV = true
+	end
+	error(SuspenseException)
+end
+
+-- ROBLOX DEVIATION: Keep the per-component counters in this module because
+-- ReactFiberHooks.new.lua is at Luau's local-register limit. Luau arrays are
+-- one-indexed, so the first thenable occupies slot 1 instead of slot 0.
+local function useThenable<T>(thenable: Thenable<T>): T
+	local index = thenableIndexCounter
+	thenableIndexCounter += 1
+	if thenableState == nil then
+		thenableState = createThenableState()
+	end
+	return trackUsedThenable(thenableState :: ThenableState, thenable, index)
+end
+
+local function resetThenableState(): ()
+	thenableIndexCounter = 1
+	thenableState = nil
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThenable.js#L319-L350
+local function getSuspendedThenable(): Thenable<any>
+	if suspendedThenable == nil then
+		error(
+			Error.new(
+				"Expected a suspended thenable. This is a bug in React. Please file an issue."
+			)
+		)
+	end
+
+	local thenable = suspendedThenable
+	suspendedThenable = nil
+	if __DEV__ then
+		needsToResetSuspendedThenableDEV = false
+	end
+	return thenable :: Thenable<any>
+end
+
+local function checkIfUseWrappedInTryCatch(): boolean
+	if __DEV__ and needsToResetSuspendedThenableDEV then
+		needsToResetSuspendedThenableDEV = false
+		return true
+	end
+	return false
+end
+
+return {
+	SuspenseException = SuspenseException,
+	checkIfUseWrappedInTryCatch = checkIfUseWrappedInTryCatch,
+	createThenableState = createThenableState,
+	getSuspendedThenable = getSuspendedThenable,
+	resetThenableState = resetThenableState,
+	trackUsedThenable = trackUsedThenable,
+	useThenable = useThenable,
+}

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -199,7 +199,6 @@ local ReactFiberThrow = require(script.Parent["ReactFiberThrow.new"]) :: any
 local throwException = ReactFiberThrow.throwException
 local createRootErrorUpdate = ReactFiberThrow.createRootErrorUpdate
 local createClassErrorUpdate = ReactFiberThrow.createClassErrorUpdate
-local ReactFiberThenable = require(script.Parent.ReactFiberThenable)
 local ReactFiberCommitWork = require(script.Parent["ReactFiberCommitWork.new"])
 local commitBeforeMutationEffectOnFiber =
 	ReactFiberCommitWork.commitBeforeMutationLifeCycles
@@ -1611,6 +1610,9 @@ mod.prepareFreshStack = function(root: FiberRoot, lanes: Lanes)
 end
 
 mod.handleError = function(root, thrownValue): ()
+	-- ROBLOX DEVIATION: Keep this require off the module scope because this file
+	-- is at Luau's top-level local limit.
+	local ReactFiberThenable = require(script.Parent.ReactFiberThenable)
 	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L2230-L2245
 	-- ROBLOX DEVIATION: React 17 has no immediate replay state machine. Convert
 	-- the opaque exception before the existing unwind, Suspense capture, and
@@ -3486,6 +3488,9 @@ if __DEV__ and ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback
 			xpcall(originalBeginWork, describeError, current, unitOfWork, lanes)
 		if not ok then
 			local originalError = result
+			-- ROBLOX DEVIATION: Keep this require off the module scope because this
+			-- file is at Luau's top-level local limit.
+			local ReactFiberThenable = require(script.Parent.ReactFiberThenable)
 
 			if
 				originalError ~= nil

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -199,6 +199,7 @@ local ReactFiberThrow = require(script.Parent["ReactFiberThrow.new"]) :: any
 local throwException = ReactFiberThrow.throwException
 local createRootErrorUpdate = ReactFiberThrow.createRootErrorUpdate
 local createClassErrorUpdate = ReactFiberThrow.createClassErrorUpdate
+local ReactFiberThenable = require(script.Parent.ReactFiberThenable)
 local ReactFiberCommitWork = require(script.Parent["ReactFiberCommitWork.new"])
 local commitBeforeMutationEffectOnFiber =
 	ReactFiberCommitWork.commitBeforeMutationLifeCycles
@@ -1610,6 +1611,14 @@ mod.prepareFreshStack = function(root: FiberRoot, lanes: Lanes)
 end
 
 mod.handleError = function(root, thrownValue): ()
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L2230-L2245
+	-- ROBLOX DEVIATION: React 17 has no immediate replay state machine. Convert
+	-- the opaque exception before the existing unwind, Suspense capture, and
+	-- ping path; cached Promise status carries the result into the retry.
+	if thrownValue == ReactFiberThenable.SuspenseException then
+		thrownValue = ReactFiberThenable.getSuspendedThenable()
+	end
+
 	while true do
 		local erroredWork = workInProgress
 		-- ROBLOX FIXME Luau: CLI-49835, "Function only returns 1 value, 2 are required"
@@ -3481,9 +3490,12 @@ if __DEV__ and ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback
 			if
 				originalError ~= nil
 				and typeof(originalError) == "table"
-				and typeof(originalError.andThen) == "function"
+				and (
+					typeof(originalError.andThen) == "function"
+					or originalError == ReactFiberThenable.SuspenseException
+				)
 			then
-				-- Don't replay promises. Treat everything else like an error.
+				-- Don't replay promises or use's opaque suspension exception.
 				error(originalError)
 			end
 

--- a/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
@@ -1,0 +1,409 @@
+--!strict
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactUse-test.js
+--[[*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+]]
+
+local Packages = script.Parent.Parent.Parent
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+
+local React
+local ReactNoop
+local Scheduler
+local Promise
+local use
+local useState
+
+local function createTextThenable()
+	local listeners: {
+		{
+			resolve: (string) -> (),
+			reject: (any) -> (),
+		}
+	} = {}
+	local thenable = {
+		andThen = function(_self, resolve, reject)
+			table.insert(listeners, { resolve = resolve, reject = reject })
+		end,
+	}
+
+	local function resolve(value: string)
+		for _, listener in listeners do
+			listener.resolve(value)
+		end
+	end
+
+	local function reject(reason: any)
+		for _, listener in listeners do
+			listener.reject(reason)
+		end
+	end
+
+	return thenable, resolve, reject
+end
+
+local function span(prop)
+	return { type = "span", hidden = false, children = {}, prop = prop }
+end
+
+local function createErrorBoundary()
+	local ErrorBoundary = React.Component:extend("ErrorBoundary")
+	function ErrorBoundary:init()
+		self.state = { error = nil }
+	end
+	function ErrorBoundary.getDerivedStateFromError(error_)
+		return { error = error_ }
+	end
+	function ErrorBoundary:render()
+		if self.state.error ~= nil then
+			return React.createElement("span", { prop = self.state.error.message })
+		end
+		return self.props.children
+	end
+	return ErrorBoundary
+end
+
+describe("ReactUse", function()
+	beforeEach(function()
+		jest.resetModules()
+
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Scheduler)
+		Promise = require(Packages.Promise)
+		use = React.use
+		useState = React.useState
+	end)
+
+	it("basic use(promise)", function()
+		local promiseA = {
+			status = "fulfilled",
+			value = "A",
+			andThen = function() end,
+		}
+		local promiseB = {
+			status = "fulfilled",
+			value = "B",
+			andThen = function() end,
+		}
+		local promiseC = {
+			status = "fulfilled",
+			value = "C",
+			andThen = function() end,
+		}
+
+		local function Text(props)
+			Scheduler.unstable_yieldValue(props.text)
+			return React.createElement("span", { prop = props.text })
+		end
+
+		local function Async()
+			local text = use(promiseA) .. use(promiseB) .. use(promiseC)
+			return React.createElement(Text, { text = text })
+		end
+
+		ReactNoop.render(React.createElement(Async))
+
+		jestExpect(Scheduler).toFlushAndYield({ "ABC" })
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("ABC") })
+	end)
+
+	it("suspends until a pending promise resolves", function()
+		local promise, resolve = createTextThenable()
+
+		local function Text(props)
+			Scheduler.unstable_yieldValue(props.text)
+			return React.createElement("span", { prop = props.text })
+		end
+
+		local function Async()
+			return React.createElement(Text, { text = use(promise) })
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				React.Suspense,
+				{ fallback = React.createElement(Text, { text = "Loading..." }) },
+				React.createElement(Async)
+			)
+		)
+
+		jestExpect(Scheduler).toFlushAndYield({ "Loading..." })
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
+
+		resolve("Async")
+
+		jestExpect(Scheduler).toFlushAndYield({ "Async" })
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Async") })
+	end)
+
+	it("instruments a Roblox Promise and retries after it resolves", function()
+		local resolvePromise: ((string) -> ())? = nil
+		local promise = Promise.new(function(resolve)
+			resolvePromise = resolve
+		end)
+
+		local function Async()
+			return React.createElement("span", { prop = use(promise) })
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				React.Suspense,
+				{ fallback = React.createElement("span", { prop = "Loading..." }) },
+				React.createElement(Async)
+			)
+		)
+		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
+
+		assert(resolvePromise ~= nil, "Promise executor did not expose its resolver")
+		resolvePromise("Async")
+		return promise:andThen(function()
+			Scheduler.unstable_flushAllWithoutAsserting()
+			jestExpect(ReactNoop.getChildren()).toEqual({ span("Async") })
+		end)
+	end)
+
+	it("using a rejected promise will throw", function()
+		local Error = require(Packages.LuauPolyfill).Error
+		local rejected = {
+			status = "rejected",
+			reason = Error.new("Oops!"),
+			andThen = function() end,
+		}
+
+		local ErrorBoundary = createErrorBoundary()
+
+		local function Async()
+			return React.createElement("span", { prop = use(rejected) })
+		end
+
+		ReactNoop.render(
+			React.createElement(ErrorBoundary, nil, React.createElement(Async))
+		)
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Oops!") })
+	end)
+
+	it("retries a pending promise rejection through an error boundary", function()
+		local Error = require(Packages.LuauPolyfill).Error
+		local promise, _, reject = createTextThenable()
+		local ErrorBoundary = createErrorBoundary()
+
+		local function Async()
+			return React.createElement("span", { prop = use(promise) })
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				ErrorBoundary,
+				nil,
+				React.createElement(
+					React.Suspense,
+					{ fallback = React.createElement("span", { prop = "Loading..." }) },
+					React.createElement(Async)
+				)
+			)
+		)
+		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
+
+		reject(Error.new("Rejected later"))
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Rejected later") })
+	end)
+
+	it("keeps thenable tracking independent between components", function()
+		local function resolved(value)
+			return {
+				andThen = function() end,
+				status = "fulfilled",
+				value = value,
+			}
+		end
+		local promiseA = resolved("A")
+		local promiseB = resolved("B")
+		local promiseC = resolved("C")
+		local promiseD = resolved("D")
+
+		local function Child(props)
+			return React.createElement("span", {
+				prop = props.prefix .. use(promiseC) .. use(promiseD),
+			})
+		end
+
+		local function Parent()
+			return React.createElement(Child, {
+				prefix = use(promiseA) .. use(promiseB),
+			})
+		end
+
+		ReactNoop.render(React.createElement(Parent))
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("ABCD") })
+	end)
+
+	it("basic use(context)", function()
+		local ContextA = React.createContext("")
+		local ContextB = React.createContext("B")
+
+		local function Sync()
+			return React.createElement("span", {
+				prop = use(ContextA) .. use(ContextB),
+			})
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				ContextA.Provider,
+				{ value = "A" },
+				React.createElement(Sync)
+			)
+		)
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("AB") })
+	end)
+
+	it("allows conditional use calls before a stateful Hook", function()
+		local Context = React.createContext("Context")
+
+		local function App(props)
+			local prefix = if props.readContext then use(Context) else "Skipped"
+			local count = useState(0)
+			return React.createElement("span", { prop = prefix .. ":" .. count })
+		end
+
+		ReactNoop.render(React.createElement(App, { readContext = false }))
+		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Skipped:0") })
+
+		ReactNoop.render(React.createElement(App, { readContext = true }))
+		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Context:0") })
+	end)
+
+	it("allows use calls in a loop before a stateful Hook", function()
+		local contexts = {
+			React.createContext("A"),
+			React.createContext("B"),
+			React.createContext("C"),
+		}
+
+		local function App()
+			local value = ""
+			for _, context in contexts do
+				value ..= use(context)
+			end
+			local count = useState(0)
+			return React.createElement("span", { prop = value .. count })
+		end
+
+		ReactNoop.render(React.createElement(App))
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("ABC0") })
+	end)
+
+	it("discards thenable positions before a render-phase update", function()
+		local promises = {
+			{
+				andThen = function() end,
+				status = "fulfilled",
+				value = "0",
+			},
+			{
+				andThen = function() end,
+				status = "fulfilled",
+				value = "1",
+			},
+		}
+
+		local function App()
+			local count, setCount = useState(0)
+			if count == 0 then
+				setCount(1)
+			end
+			return React.createElement("span", { prop = use(promises[count + 1]) })
+		end
+
+		ReactNoop.render(React.createElement(App))
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("1") })
+	end)
+
+	it("unwraps thenable that fulfills synchronously without suspending", function()
+		local thenable = {
+			andThen = function(_self, resolve)
+				resolve("Hi")
+			end,
+		}
+
+		local function App()
+			return React.createElement("span", { prop = use(thenable) })
+		end
+
+		ReactNoop.flushSync(function()
+			ReactNoop.render(React.createElement(App))
+		end)
+
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Hi") })
+	end)
+
+	it("warns if use(promise) is wrapped with try/catch", function()
+		local promise = { andThen = function() end }
+
+		local function App()
+			pcall(function()
+				use(promise)
+			end)
+			return React.createElement("span", { prop = "Caught" })
+		end
+
+		jestExpect(function()
+			ReactNoop.render(React.createElement(App))
+			Scheduler.unstable_flushAllWithoutAsserting()
+		end).toErrorDev(
+			"`use` was called from inside a try/catch block. This is not allowed "
+				.. "and can lead to unexpected behavior. To handle errors triggered "
+				.. "by `use`, wrap your component in a error boundary.",
+			{ withoutStack = true }
+		)
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Caught") })
+	end)
+
+	it("resets the dispatcher after a component suspends", function()
+		local promise = { andThen = function() end }
+		local function Async()
+			return React.createElement("span", { prop = use(promise) })
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				React.Suspense,
+				{ fallback = React.createElement("span", { prop = "Loading..." }) },
+				React.createElement(Async)
+			)
+		)
+		Scheduler.unstable_flushAllWithoutAsserting()
+
+		jestExpect(function()
+			useState(0)
+		end).toThrow("Invalid hook call")
+	end)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
@@ -405,14 +405,16 @@ describe("ReactUse", function()
 			return React.createElement(Text, { text = "Caught" })
 		end
 
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactUse-test.js#L534-L568
+		-- ROBLOX DEVIATION: React 17 appends the component stack through the
+		-- console harness; toErrorDev preserves the upstream warning count and text.
 		jestExpect(function()
 			ReactNoop.render(React.createElement(App))
 			jestExpect(Scheduler).toFlushAndYield({ "Caught" })
 		end).toErrorDev(
 			"`use` was called from inside a try/catch block. This is not allowed "
 				.. "and can lead to unexpected behavior. To handle errors triggered "
-				.. "by `use`, wrap your component in a error boundary.",
-			{ withoutStack = true }
+				.. "by `use`, wrap your component in a error boundary."
 		)
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Caught") })
 	end)

--- a/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactUse.spec.lua
@@ -56,6 +56,11 @@ local function span(prop)
 	return { type = "span", hidden = false, children = {}, prop = prop }
 end
 
+local function Text(props)
+	Scheduler.unstable_yieldValue(props.text)
+	return React.createElement("span", { prop = props.text })
+end
+
 local function createErrorBoundary()
 	local ErrorBoundary = React.Component:extend("ErrorBoundary")
 	function ErrorBoundary:init()
@@ -66,7 +71,7 @@ local function createErrorBoundary()
 	end
 	function ErrorBoundary:render()
 		if self.state.error ~= nil then
-			return React.createElement("span", { prop = self.state.error.message })
+			return React.createElement(Text, { text = self.state.error.message })
 		end
 		return self.props.children
 	end
@@ -83,6 +88,40 @@ describe("ReactUse", function()
 		Promise = require(Packages.Promise)
 		use = React.use
 		useState = React.useState
+	end)
+
+	it("does not infinite loop if already fulfilled thenable is thrown", function()
+		-- An already fulfilled Promise should never be thrown. If it is, React
+		-- must show the fallback without retrying the render indefinitely.
+		local thenable = {
+			andThen = function() end,
+			status = "fulfilled",
+		}
+
+		local renderCount = 0
+		local function Async()
+			renderCount += 1
+			if renderCount > 50 then
+				error("Infinite loop detected")
+			end
+			Scheduler.unstable_yieldValue("Suspend!")
+			-- A userspace Suspense library made the implementation mistake that
+			-- this regression covers.
+			error(thenable)
+		end
+
+		ReactNoop.render(
+			React.createElement(
+				React.Suspense,
+				{ fallback = React.createElement(Text, { text = "Loading..." }) },
+				React.createElement(Async)
+			)
+		)
+
+		-- ROBLOX DEVIATION: React 17 has no sibling prewarming pass, so Async
+		-- renders once instead of React 19's second post-fallback attempt.
+		jestExpect(Scheduler).toFlushAndYield({ "Suspend!", "Loading..." })
+		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
 	end)
 
 	it("basic use(promise)", function()
@@ -102,11 +141,6 @@ describe("ReactUse", function()
 			andThen = function() end,
 		}
 
-		local function Text(props)
-			Scheduler.unstable_yieldValue(props.text)
-			return React.createElement("span", { prop = props.text })
-		end
-
 		local function Async()
 			local text = use(promiseA) .. use(promiseB) .. use(promiseC)
 			return React.createElement(Text, { text = text })
@@ -120,11 +154,6 @@ describe("ReactUse", function()
 
 	it("suspends until a pending promise resolves", function()
 		local promise, resolve = createTextThenable()
-
-		local function Text(props)
-			Scheduler.unstable_yieldValue(props.text)
-			return React.createElement("span", { prop = props.text })
-		end
 
 		local function Async()
 			return React.createElement(Text, { text = use(promise) })
@@ -154,23 +183,23 @@ describe("ReactUse", function()
 		end)
 
 		local function Async()
-			return React.createElement("span", { prop = use(promise) })
+			return React.createElement(Text, { text = use(promise) })
 		end
 
 		ReactNoop.render(
 			React.createElement(
 				React.Suspense,
-				{ fallback = React.createElement("span", { prop = "Loading..." }) },
+				{ fallback = React.createElement(Text, { text = "Loading..." }) },
 				React.createElement(Async)
 			)
 		)
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Loading..." })
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
 
 		assert(resolvePromise ~= nil, "Promise executor did not expose its resolver")
 		resolvePromise("Async")
 		return promise:andThen(function()
-			Scheduler.unstable_flushAllWithoutAsserting()
+			jestExpect(Scheduler).toFlushAndYield({ "Async" })
 			jestExpect(ReactNoop.getChildren()).toEqual({ span("Async") })
 		end)
 	end)
@@ -192,7 +221,7 @@ describe("ReactUse", function()
 		ReactNoop.render(
 			React.createElement(ErrorBoundary, nil, React.createElement(Async))
 		)
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Oops!", "Oops!" })
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Oops!") })
 	end)
@@ -203,7 +232,7 @@ describe("ReactUse", function()
 		local ErrorBoundary = createErrorBoundary()
 
 		local function Async()
-			return React.createElement("span", { prop = use(promise) })
+			return React.createElement(Text, { text = use(promise) })
 		end
 
 		ReactNoop.render(
@@ -212,16 +241,16 @@ describe("ReactUse", function()
 				nil,
 				React.createElement(
 					React.Suspense,
-					{ fallback = React.createElement("span", { prop = "Loading..." }) },
+					{ fallback = React.createElement(Text, { text = "Loading..." }) },
 					React.createElement(Async)
 				)
 			)
 		)
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Loading..." })
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Loading...") })
 
 		reject(Error.new("Rejected later"))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Rejected later", "Rejected later" })
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Rejected later") })
 	end)
@@ -240,8 +269,8 @@ describe("ReactUse", function()
 		local promiseD = resolved("D")
 
 		local function Child(props)
-			return React.createElement("span", {
-				prop = props.prefix .. use(promiseC) .. use(promiseD),
+			return React.createElement(Text, {
+				text = props.prefix .. use(promiseC) .. use(promiseD),
 			})
 		end
 
@@ -252,7 +281,7 @@ describe("ReactUse", function()
 		end
 
 		ReactNoop.render(React.createElement(Parent))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "ABCD" })
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("ABCD") })
 	end)
@@ -274,7 +303,7 @@ describe("ReactUse", function()
 				React.createElement(Sync)
 			)
 		)
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({})
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("AB") })
 	end)
@@ -285,15 +314,15 @@ describe("ReactUse", function()
 		local function App(props)
 			local prefix = if props.readContext then use(Context) else "Skipped"
 			local count = useState(0)
-			return React.createElement("span", { prop = prefix .. ":" .. count })
+			return React.createElement(Text, { text = prefix .. ":" .. count })
 		end
 
 		ReactNoop.render(React.createElement(App, { readContext = false }))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Skipped:0" })
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Skipped:0") })
 
 		ReactNoop.render(React.createElement(App, { readContext = true }))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Context:0" })
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Context:0") })
 	end)
 
@@ -310,11 +339,11 @@ describe("ReactUse", function()
 				value ..= use(context)
 			end
 			local count = useState(0)
-			return React.createElement("span", { prop = value .. count })
+			return React.createElement(Text, { text = value .. count })
 		end
 
 		ReactNoop.render(React.createElement(App))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "ABC0" })
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("ABC0") })
 	end)
@@ -338,11 +367,11 @@ describe("ReactUse", function()
 			if count == 0 then
 				setCount(1)
 			end
-			return React.createElement("span", { prop = use(promises[count + 1]) })
+			return React.createElement(Text, { text = use(promises[count + 1]) })
 		end
 
 		ReactNoop.render(React.createElement(App))
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "1" })
 
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("1") })
 	end)
@@ -355,13 +384,14 @@ describe("ReactUse", function()
 		}
 
 		local function App()
-			return React.createElement("span", { prop = use(thenable) })
+			return React.createElement(Text, { text = use(thenable) })
 		end
 
 		ReactNoop.flushSync(function()
 			ReactNoop.render(React.createElement(App))
 		end)
 
+		jestExpect(Scheduler).toHaveYielded({ "Hi" })
 		jestExpect(ReactNoop.getChildren()).toEqual({ span("Hi") })
 	end)
 
@@ -372,12 +402,12 @@ describe("ReactUse", function()
 			pcall(function()
 				use(promise)
 			end)
-			return React.createElement("span", { prop = "Caught" })
+			return React.createElement(Text, { text = "Caught" })
 		end
 
 		jestExpect(function()
 			ReactNoop.render(React.createElement(App))
-			Scheduler.unstable_flushAllWithoutAsserting()
+			jestExpect(Scheduler).toFlushAndYield({ "Caught" })
 		end).toErrorDev(
 			"`use` was called from inside a try/catch block. This is not allowed "
 				.. "and can lead to unexpected behavior. To handle errors triggered "
@@ -396,11 +426,11 @@ describe("ReactUse", function()
 		ReactNoop.render(
 			React.createElement(
 				React.Suspense,
-				{ fallback = React.createElement("span", { prop = "Loading..." }) },
+				{ fallback = React.createElement(Text, { text = "Loading..." }) },
 				React.createElement(Async)
 			)
 		)
-		Scheduler.unstable_flushAllWithoutAsserting()
+		jestExpect(Scheduler).toFlushAndYield({ "Loading..." })
 
 		jestExpect(function()
 			useState(0)

--- a/modules/react-shallow-renderer/src/__tests__/ReactShallowRendererHooks.spec.lua
+++ b/modules/react-shallow-renderer/src/__tests__/ReactShallowRendererHooks.spec.lua
@@ -34,6 +34,49 @@ local function validateElement(element)
 end
 
 describe("ReactShallowRenderer with hooks", function()
+	it("should read a fulfilled promise with use", function()
+		local promise = {
+			andThen = function() end,
+			status = "fulfilled",
+			value = "resolved",
+		}
+		local function SomeComponent()
+			return React.createElement("TextLabel", { Text = React.use(promise) })
+		end
+
+		local result = createRenderer():render(React.createElement(SomeComponent))
+
+		jestExpect(result).toEqual(
+			React.createElement("TextLabel", { Text = "resolved" })
+		)
+	end)
+
+	it("should read context with use", function()
+		local Context = React.createContext("context")
+		local function SomeComponent()
+			return React.createElement("TextLabel", { Text = React.use(Context) })
+		end
+
+		local result = createRenderer():render(React.createElement(SomeComponent))
+
+		jestExpect(result).toEqual(React.createElement("TextLabel", { Text = "context" }))
+	end)
+
+	it("should throw a rejected promise reason from use", function()
+		local rejected = {
+			andThen = function() end,
+			status = "rejected",
+			reason = "Oops!",
+		}
+		local function SomeComponent()
+			return React.use(rejected)
+		end
+
+		jestExpect(function()
+			createRenderer():render(React.createElement(SomeComponent))
+		end).toThrow("Oops!")
+	end)
+
 	it("should work with useState", function()
 		local function SomeComponent(props)
 			local name = React.useState(props.defaultName)

--- a/modules/react-shallow-renderer/src/init.lua
+++ b/modules/react-shallow-renderer/src/init.lua
@@ -30,6 +30,7 @@ local checkPropTypes = require(Packages.Shared).checkPropTypes
 local ReactSharedInternals = require(Packages.Shared).ReactSharedInternals
 local consoleWithStackDev = require(Packages.Shared).consoleWithStackDev
 local is = require(Packages.Shared).objectIs
+local REACT_CONTEXT_TYPE = require(Packages.Shared).ReactSymbols.REACT_CONTEXT_TYPE
 
 local ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher
 local ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame
@@ -350,6 +351,26 @@ function ReactShallowRenderer:_createDispatcher()
 		return context._currentValue
 	end
 
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L1151-L1166
+	-- ROBLOX DEVIATION: The shallow renderer has no Suspense work loop. Pending
+	-- thenables are rethrown directly for the caller to handle.
+	local function use(usable)
+		self:_validateCurrentlyRenderingComponent()
+		if usable ~= nil and typeof(usable) == "table" then
+			if typeof(usable.andThen) == "function" then
+				if usable.status == "fulfilled" then
+					return usable.value
+				elseif usable.status == "rejected" then
+					error(usable.reason)
+				end
+				error(usable)
+			elseif usable["$$typeof"] == REACT_CONTEXT_TYPE then
+				return readContext(usable)
+			end
+		end
+		error(Error("An unsupported type was passed to use(): " .. tostring(usable)))
+	end
+
 	local function noOp()
 		self:_validateCurrentlyRenderingComponent()
 	end
@@ -382,6 +403,7 @@ function ReactShallowRenderer:_createDispatcher()
 
 	return {
 		readContext = readContext,
+		use = use,
 		useCallback = identity,
 		useContext = function(context)
 			self:_validateCurrentlyRenderingComponent()

--- a/modules/react/src/React.lua
+++ b/modules/react/src/React.lua
@@ -95,6 +95,7 @@ return {
 	lazy = ReactLazy.lazy,
 	memo = ReactMemo.memo,
 	useCallback = ReactHooks.useCallback,
+	use = ReactHooks.use,
 	useContext = ReactHooks.useContext,
 	useEffect = ReactHooks.useEffect,
 	useImperativeHandle = ReactHooks.useImperativeHandle,

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -31,6 +31,7 @@ type MutableSourceSubscribeFn<Source, Snapshot> = ReactTypes.MutableSourceSubscr
 >
 type ReactProviderType<T> = ReactTypes.ReactProviderType<T>
 type ReactContext<T> = ReactTypes.ReactContext<T>
+type Usable<T> = ReactTypes.Usable<T>
 local ReactFiberHostConfig = require(Packages.Shared)
 type OpaqueIDType = ReactFiberHostConfig.OpaqueIDType
 
@@ -65,6 +66,13 @@ local function resolveDispatcher(): Dispatcher
 end
 
 local exports = {}
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react/src/ReactHooks.js#L206-L210
+local function use<T>(usable: Usable<T>): T
+	local dispatcher = resolveDispatcher()
+	return dispatcher.use(usable)
+end
+exports.use = use
 
 --[[
 	Accepts a context object (the value returned from `React.createContext`)

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -67,7 +67,7 @@ end
 
 local exports = {}
 
--- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react/src/ReactHooks.js#L206-L210
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react/src/ReactHooks.js#L207-L211
 local function use<T>(usable: Usable<T>): T
 	local dispatcher = resolveDispatcher()
 	return dispatcher.use(usable)

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -22,6 +22,7 @@ type Source = ReactElementType.Source
 local ReactTypes = require(script.Parent.Parent.ReactTypes)
 type RefObject = ReactTypes.RefObject
 type ReactContext<T> = ReactTypes.ReactContext<T>
+type Usable<T> = ReactTypes.Usable<T>
 -- ROBLOX deviation START: binding support
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
@@ -41,6 +42,7 @@ type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
 
 export type Dispatcher = {
+	use: <T>(usable: Usable<T>) -> T,
 	readContext: <T>(
 		context: ReactContext<T>,
 		observedBits: nil | number | boolean

--- a/modules/shared/src/ReactTypes.lua
+++ b/modules/shared/src/ReactTypes.lua
@@ -255,6 +255,8 @@ export type _Thenable<R> = {
 	) -> (),
 }
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/shared/ReactTypes.js#L103-L145
+-- ROBLOX DEVIATION: Roblox Promise-compatible thenables expose `andThen` instead of `then`.
 export type Thenable<R> = {
 	andThen: <U>(
 		self: Thenable<R>,
@@ -262,6 +264,11 @@ export type Thenable<R> = {
 		onReject: (error: any) -> ...(_Thenable<U> | U)
 		-- ROBLOX FIXME Luau: need union type packs to parse () | Thenable<U>: CLI-49836
 	) -> nil | _Thenable<U>,
+	status: string?,
+	value: R?,
+	reason: any?,
 }
+
+export type Usable<T> = Thenable<T> | ReactContext<T>
 
 return exports

--- a/modules/shared/src/init.lua
+++ b/modules/shared/src/init.lua
@@ -60,6 +60,7 @@ export type MutableSourceGetVersionFn = ReactTypes.MutableSourceGetVersionFn
 export type MutableSource<Source> = ReactTypes.MutableSource<Source>
 export type Wakeable = ReactTypes.Wakeable
 export type Thenable<R> = ReactTypes.Thenable<R>
+export type Usable<T> = ReactTypes.Usable<T>
 export type Source = ReactElementType.Source
 export type ReactElement<P = Object, T = any> = ReactElementType.ReactElement<P, T>
 export type OpaqueIDType = ReactFiberHostConfig.OpaqueIDType


### PR DESCRIPTION
## Summary

- add stable React 19.2 `use(Context)` and cached Promise-compatible thenable reads
- add generic reconciler thenable tracking, opaque suspension bridging, and retry/error behavior
- support conditional and looped `use` calls without normal Hook ordering
- add Debug Tools, shallow renderer, API docs, and a pinned upstream ledger

## Compatibility boundary

This is the client cached-Promise API. Promises must be created and cached outside render, must settle normally, and expose `andThen`. React 19 server/RSC behavior, cache APIs, hydration, sibling prewarming, Actions, Promise-as-child, async components, and uncached component replay are excluded. Roblox Promise cancellation is unsupported because ordinary `andThen` listeners are not notified reliably.

React-Luau 17 has no React 19 `SuspendedOnImmediate` replay state machine. The opaque `use` exception is therefore converted before the existing unwind, Suspense capture, ping, and retry path; the cached Promise's instrumented status survives the retry.

## Provenance

- runtime and tests are pinned to React 19.2.0 at `ae74234eae6ebd62f19190731278e20bc1c37d51`
- the swallowed try/catch warning follows [`ReactUse-test.js` lines 534-568](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactUse-test.js#L534-L568): exactly one warning containing the complete upstream text
- React 17's console harness appends the component stack, so the translated `toErrorDev` assertion validates the stack instead of incorrectly requiring its absence; this adaptation is marked at the test site

The implementation and complete test/deviation classification are pinned in `docs/backports/react-19-use.md`.

## Verification

Exact candidate: `706beab31c8dd20dc824e2254743da0bd87dfedc` / tree `f82a837524a8281e9c3af8c6e8450124b056bc77`

- preserved RED baseline at `28c57e5d4ab256956980c4fd3bf9f4d3c865630e`: identity 1/1; ReactUse 13/14, with the expected warning text/count and component stack rejected only by the unsupported no-stack matcher option
- hardened Studio `debug.loadmodule` rerun: identity 1/1 and complete ReactUse 14/14, including the try/catch warning regression
- archive SHA-256: `1E1168AB3994E61A079852A148CCD70E4965C1C65374EF31E729337CBF92B59F`
- project SHA-256: `2302E858AE23831EBBE5FF0BFF2A351940F97CF6CEFE78C733940E835910457D`
- config SHA-256: `A5800572BCEBADA709F02E0BA9C9E486EEC8919B40CBCDBFD7D5D71BF07E7C71`
- ReactUse Jest SHA-256: `FAEEADA030DAA0BC6D41CBB8085E1CED9E3A1F3E13E7FA81FD2B6D03A5050E67`
- identity Jest SHA-256: `D9984A6FE84B2A031B55DA85B5470C88EFAF73C4F7819C3434FA3159F8E84A59`
- full Selene 0.28.0: passed
- full StyLua 0.18.1 check: passed
- Luau bytecode compilation for every changed Lua file: passed
- WorkLoop compiler register probe: R188, matching the known-good reconciler chunk
- git diff and public privacy checks: passed
- canonical `bin/ci.sh`: dependency installation, Roblox analysis, and DEV/release runtime stages remain unavailable locally because the pinned Roblox-internal Foreman sources and required CLI binaries are not accessible

Generated with Codex.

