### PR TITLE
Backport useDeferredValue initial values

### DIFF
--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -52,6 +52,10 @@ type React_Node = ReactTypes.React_Node
 -- ROBLOX deviation START: add binding support
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 -- ROBLOX deviation END
 -- ROBLOX deviation START: fix import
 -- local reactReconcilerSrcReactInternalTypesModule =
@@ -217,8 +221,7 @@ local function getPrimitiveStackCache(): Map<string, Array<any>>
 end
 local currentHook: nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook =
 	nil
-local function nextHook(
-): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
+local function nextHook(): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
 	local hook = currentHook
 	if hook ~= nil then
 		currentHook = hook.next
@@ -444,33 +447,28 @@ local function useMutableSource<Source, Snapshot>(
 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
 	return value
 end
--- ROBLOX deviation START: enable these once they are fully enabled in the Dispatcher type and in ReactFiberHooks' myriad dispatchers
--- local function useTransition(
--- ): any --[[ ROBLOX TODO: Unhandled node for type: TupleTypeAnnotation ]] --[[ [(() => void) => void, boolean] ]]
--- 	-- useTransition() composes multiple hooks internally.
--- 	-- Advance the current hook index the same number of times
--- 	-- so that subsequent hooks have the right memoized state.
--- 	nextHook() -- State
--- 	nextHook() -- Callback
--- 	table.insert(
--- 		hookLog,
--- 		{ primitive = "Transition", stackError = Error.new(), value = nil }
--- 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
--- 	return { function(callback) end, false }
--- end
--- local function useDeferredValue<T>(value: T): T
--- 	-- useDeferredValue() composes multiple hooks internally.
--- 	-- Advance the current hook index the same number of times
--- 	-- so that subsequent hooks have the right memoized state.
--- 	nextHook() -- State
--- 	nextHook() -- Effect
--- 	table.insert(
--- 		hookLog,
--- 		{ primitive = "DeferredValue", stackError = Error.new(), value = value }
--- 	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
--- 	return value
--- end
--- ROBLOX deviation END
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/ReactDebugHooks.js#L298-L315
+-- ROBLOX deviation: Luau represents React's tuple as multiple return values.
+local function useTransition(): (boolean, StartTransition)
+	nextHook() -- State
+	nextHook() -- Callback
+	table.insert(
+		hookLog,
+		{ primitive = "Transition", stackError = Error.new(), value = nil }
+	)
+	return false, function(_callback, _options) end
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/72ebc703ac8abacd44fdeb1e3d66eb28b75e5a5b/packages/react-debug-tools/src/ReactDebugHooks.js#L312-L322
+local function useDeferredValue<T>(value: T): T
+	local hook = nextHook()
+	table.insert(hookLog, {
+		primitive = "DeferredValue",
+		stackError = Error.new(),
+		value = if hook ~= nil then hook.memoizedState else value,
+	})
+	return value
+end
 local function useOpaqueIdentifier(): OpaqueIDType | void
 	local hook = nextHook() -- State
 	-- ROBLOX deviation START: simplify
@@ -531,13 +529,9 @@ Dispatcher = {
 	-- useState = useState,
 	useState = useState :: any,
 	-- ROBLOX deviation END
-	-- ROBLOX deviation START: not implemented
-	-- useTransition = useTransition,
-	-- ROBLOX deviation END
+	useTransition = useTransition,
 	useMutableSource = useMutableSource,
-	-- ROBLOX deviation START: not implemented
-	-- useDeferredValue = useDeferredValue,
-	-- ROBLOX deviation END
+	useDeferredValue = useDeferredValue,
 	useOpaqueIdentifier = useOpaqueIdentifier,
 } -- Inspect
 export type HooksNode = {

--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -52,10 +52,7 @@ type React_Node = ReactTypes.React_Node
 -- ROBLOX deviation START: add binding support
 type ReactBinding<T> = ReactTypes.ReactBinding<T>
 type ReactBindingUpdater<T> = ReactTypes.ReactBindingUpdater<T>
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 -- ROBLOX deviation END
 -- ROBLOX deviation START: fix import
 -- local reactReconcilerSrcReactInternalTypesModule =
@@ -221,7 +218,8 @@ local function getPrimitiveStackCache(): Map<string, Array<any>>
 end
 local currentHook: nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook =
 	nil
-local function nextHook(): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
+local function nextHook(
+): nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]] | Hook
 	local hook = currentHook
 	if hook ~= nil then
 		currentHook = hook.next

--- a/modules/react-debug-tools/src/ReactDebugHooks.lua
+++ b/modules/react-debug-tools/src/ReactDebugHooks.lua
@@ -74,6 +74,7 @@ local NoMode = ReconcilerModule.ReactTypeOfMode.NoMode
 -- ROBLOX deviation END
 -- ROBLOX deviation START: add inline ErrorStackParser implementation
 -- local ErrorStackParser = require(Packages["error-stack-parser"]).default
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/ReactDebugHooks.js#L23
 type StackFrame = {
 	source: string?,
 	functionName: string?,
@@ -86,7 +87,10 @@ local ErrorStackParser = {
 		local filtered = Array.filter(
 			string.split(error_.stack :: string, "\n"),
 			function(line)
+				-- ROBLOX DEVIATION: Roblox emits both legacy LoadedCode frames and
+				-- current Luau [string "..."] frames. Shared with PR #28.
 				return string.find(line, "^LoadedCode") ~= nil
+					or string.find(line, '^%[string "') ~= nil
 			end
 		)
 		return Array.map(filtered, function(stackTraceLine)
@@ -402,6 +406,7 @@ end
 -- 	nextCreate: () -> T,
 -- 	inputs: Array<unknown> | void | nil --[[ ROBLOX CHECK: verify if `null` wasn't used differently than `undefined` ]]
 -- ): T
+-- ROBLOX upstream: https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/packages/react-debug-tools/src/ReactDebugHooks.js#L229-L237
 local function useMemo<T...>(nextCreate: () -> T..., inputs: Array<any> | nil): ...any
 	-- ROBLOX deviation END
 	local hook = nextHook()
@@ -414,7 +419,13 @@ local function useMemo<T...>(nextCreate: () -> T..., inputs: Array<any> | nil): 
 	local value = if hook ~= nil then hook.memoizedState[1] else { nextCreate() }
 	-- ROBLOX deviation END
 
-	table.insert(hookLog, { primitive = "Memo", stackError = Error.new(), value = value }) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
+	-- ROBLOX DEVIATION: DevTools displays a single Luau memo return as its value,
+	-- but preserves a multi-return pack. Shared with PR #28.
+	local inspectedValue = if #value <= 1 then value[1] else value
+	table.insert(
+		hookLog,
+		{ primitive = "Memo", stackError = Error.new(), value = inspectedValue }
+	) --[[ ROBLOX CHECK: check if 'hookLog' is an Array ]]
 	-- ROBLOX deviation START: unwrap memoized values in a table
 	-- return value
 	return table.unpack(value)
@@ -458,14 +469,17 @@ local function useTransition(): (boolean, StartTransition)
 end
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/72ebc703ac8abacd44fdeb1e3d66eb28b75e5a5b/packages/react-debug-tools/src/ReactDebugHooks.js#L312-L322
-local function useDeferredValue<T>(value: T): T
+-- ROBLOX upstream: https://github.com/facebook/react/blob/7268dacf70cd6a7f5705a19053aad46b5289ab72/packages/react-debug-tools/src/ReactDebugHooks.js#L445-L456
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-debug-tools/src/ReactDebugHooks.js#L507-L518
+local function useDeferredValue<T>(value: T, _initialValue: T?): T
 	local hook = nextHook()
+	local prevValue = if hook ~= nil then hook.memoizedState else value
 	table.insert(hookLog, {
 		primitive = "DeferredValue",
 		stackError = Error.new(),
-		value = if hook ~= nil then hook.memoizedState else value,
+		value = prevValue,
 	})
-	return value
+	return prevValue
 end
 local function useOpaqueIdentifier(): OpaqueIDType | void
 	local hook = nextHook() -- State
@@ -558,11 +572,18 @@ local mostLikelyAncestorIndex = 1
 -- ROBLOX deviation END
 -- ROBLOX deviation START: explicit type
 -- local function findSharedIndex(hookStack, rootStack, rootIndex)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/packages/react-debug-tools/src/ReactDebugHooks.js#L347-L365
 local function findSharedIndex(hookStack, rootStack, rootIndex: number)
 	-- ROBLOX deviation END
 	-- ROBLOX deviation START: don't use tostring
 	-- local source = rootStack[tostring(rootIndex)].source
-	local source = rootStack[rootIndex].source
+	-- ROBLOX DEVIATION: Roblox can omit the ancestor frame from a parsed stack.
+	-- Shared with PR #28.
+	local rootFrame = rootStack[rootIndex]
+	if rootFrame == nil then
+		return -1
+	end
+	local source = rootFrame.source
 	-- ROBLOX deviation END
 	-- ROBLOX deviation START: implement LabeledStatement
 	-- 	error("not implemented") --[[ ROBLOX TODO: Unhandled node for type: LabeledStatement ]] --[[ hookSearch: for (let i = 0; i < hookStack.length; i++) {

--- a/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
+++ b/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
@@ -538,14 +538,10 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
-	-- ROBLOX deviation START: unstable_useTransition is not implemented
-	-- it("should support composite useTransition hook", function()
-	it.skip("should support composite useTransition hook", function()
-		-- ROBLOX deviation END
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+	it("should support composite useTransition hook", function()
 		local function Foo(props)
-			-- ROBLOX deviation START: not supported
-			-- React.unstable_useTransition()
-			-- ROBLOX deviation END
+			React.useTransition()
 			local memoizedValue = React.useMemo(function()
 				return "hello"
 			end, {})
@@ -585,23 +581,19 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
-	-- ROBLOX deviation START: unstable_useDeferredValue not implemented
-	-- it("should support composite useDeferredValue hook", function()
-	it.skip("should support composite useDeferredValue hook", function()
-		-- ROBLOX deviation END
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/72ebc703ac8abacd44fdeb1e3d66eb28b75e5a5b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js#L582-L626
+	it("should support composite useDeferredValue hook", function()
 		local function Foo(props)
-			-- ROBLOX deviation START: not implemented
-			-- React.unstable_useDeferredValue("abc", { timeoutMs = 500 })
-			-- ROBLOX deviation END
-			local state = React.useState(function()
+			React.useDeferredValue("abc")
+			local memoizedValue = React.useMemo(function()
 				return "hello"
-				-- ROBLOX deviation START: useState returns 2 values
-				-- end, {})[1]
 			end, {})
-			-- ROBLOX deviation END
+			React.useMemo(function()
+				return "world"
+			end, {})
 			-- ROBLOX deviation START: use Frame instead
-			-- return React.createElement("div", nil, state)
-			return React.createElement("Frame", nil, state)
+			-- return React.createElement("div", nil, memoizedValue)
+			return React.createElement("Frame", nil, memoizedValue)
 			-- ROBLOX deviation END
 		end
 		local renderer = ReactTestRenderer.create(React.createElement(Foo, nil))
@@ -626,9 +618,16 @@ describe("ReactHooksInspectionIntegration", function()
 				-- id = 1,
 				id = 2,
 				-- ROBLOX deviation END
-				isStateEditable = true,
-				name = "State",
+				isStateEditable = false,
+				name = "Memo",
 				value = "hello",
+				subHooks = {},
+			},
+			{
+				id = 3,
+				isStateEditable = false,
+				name = "Memo",
+				value = "world",
 				subHooks = {},
 			},
 		})

--- a/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
+++ b/modules/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration.spec.lua
@@ -1,3 +1,6 @@
+--!optimize 0
+-- ROBLOX DEVIATION: Debug Tools inspection requires custom-hook stack frames
+-- that optimized Luau can elide. Shared with PR #28.
 -- ROBLOX upstream: https://github.com/facebook/react/blob/v17.0.2/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
@@ -168,6 +171,8 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end)
+	-- ROBLOX DEVIATION: Shared with PR #28, scalar Luau useMemo results are
+	-- inspected as values rather than packed return tables.
 	it("should inspect the current state of all stateful hooks", function()
 		local outsideRef = React.createRef()
 		local function effect() end
@@ -298,10 +303,7 @@ describe("ReactHooksInspectionIntegration", function()
 				id = 7,
 				-- ROBLOX deviation END
 				name = "Memo",
-				-- ROBLOX deviation START: useMemo wraps a value
-				-- value = "ab",
-				value = { "ab" },
-				-- ROBLOX deviation END
+				value = "ab",
 				subHooks = {},
 			},
 			{
@@ -385,10 +387,7 @@ describe("ReactHooksInspectionIntegration", function()
 				id = 7,
 				-- ROBLOX deviation END
 				name = "Memo",
-				-- ROBLOX deviation START: useMemo wraps a value
-				-- value = "Ab",
-				value = { "Ab" },
-				-- ROBLOX deviation END
+				value = "Ab",
 				subHooks = {},
 			},
 			{
@@ -538,6 +537,31 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
+	-- ROBLOX DEVIATION: A single nil Luau memo result must not be exposed as its
+	-- packed return table. This shared PR #28 normalization is deduplicated when
+	-- the branches are stacked.
+	it("should inspect a nil useMemo value", function()
+		local function Foo()
+			React.useMemo(function()
+				return nil
+			end, {})
+			return React.createElement("Frame")
+		end
+
+		local renderer = ReactTestRenderer.create(React.createElement(Foo))
+		local childFiber = renderer.root:findByType(Foo):_currentFiber()
+		local tree = ReactDebugTools.inspectHooksOfFiber(childFiber)
+
+		expect(tree).toEqual({
+			{
+				id = 1,
+				isStateEditable = false,
+				name = "Memo",
+				value = nil :: any,
+				subHooks = {},
+			},
+		})
+	end)
 	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
 	it("should support composite useTransition hook", function()
 		local function Foo(props)
@@ -632,6 +656,217 @@ describe("ReactHooksInspectionIntegration", function()
 			},
 		})
 	end) -- @gate experimental
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/7268dacf70cd6a7f5705a19053aad46b5289ab72/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js#L1209-L1465
+	it("should return the deferred value", function()
+		local unsuspend
+		local function Lazy()
+			return nil
+		end
+		local Suspender = React.lazy(function()
+			-- ROBLOX DEVIATION: Use the Luau Promise constructor and resolve with the
+			-- lazy module table instead of a JavaScript Promise.
+			return Promise.new(function(resolve)
+				unsuspend = function()
+					resolve({ default = Lazy })
+				end
+			end)
+		end)
+		local Context = React.createContext("default")
+		local ReactSharedInternals =
+			React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+		local isInspectingHooks = false
+		local function inspectHooks(fiber)
+			isInspectingHooks = true
+			local tree = ReactDebugTools.inspectHooksOfFiber(fiber)
+			isInspectingHooks = false
+			return tree
+		end
+		local setShow
+		local function Foo(props)
+			local show, setShow_ = React.useState(false)
+			local deferredShow = React.useDeferredValue(show)
+			local isPending = show ~= deferredShow
+			local contextDisplay = "<none>"
+			if isPending then
+				local dispatcher = ReactSharedInternals.ReactCurrentDispatcher.current
+				-- ROBLOX DEVIATION: React 17 has no conditional use API. Inline the
+				-- slotless renderer read and inspection useContext so Debug Tools logs
+				-- the Context primitive without an adapter custom-hook frame.
+				contextDisplay = if isInspectingHooks
+					then dispatcher.useContext(Context)
+					else dispatcher.readContext(Context)
+			end
+			React.useMemo(function()
+				return "hello"
+			end, {})
+			React.useMemo(function()
+				return "not used"
+			end, {})
+
+			-- ROBLOX DEVIATION: React 17 concurrent roots replay mounts in StrictMode.
+			-- Capture every renderer setter without accepting the Debug Tools setter.
+			if not isInspectingHooks then
+				setShow = setShow_
+			end
+
+			local output = "Context: "
+				.. contextDisplay
+				.. ", "
+				.. (if isPending then "Pending" else "Nothing Pending")
+			if deferredShow then
+				output ..= ", Lazy"
+			end
+
+			-- ROBLOX DEVIATION: Represent upstream text output with a TextLabel
+			-- prop because Roblox host text nodes are not concatenated.
+			return React.createElement(
+				React.Suspense,
+				{
+					fallback = React.createElement("TextLabel", { Text = "Loading" }),
+				},
+				React.createElement(
+					"TextLabel",
+					{ Text = output },
+					if deferredShow then React.createElement(Suspender) else nil
+				)
+			)
+		end
+
+		local renderer
+		-- ROBLOX DEVIATION: This React 17 Jest-Lua act is synchronous; upstream
+		-- awaits each act scope.
+		act(function()
+			renderer = ReactTestRenderer.create(
+				React.createElement(
+					Context.Provider,
+					{ value = "provided" },
+					React.createElement(Foo)
+				),
+				-- ROBLOX DEVIATION: React 17 TestRenderer uses the unstable option name.
+				{ unstable_isConcurrent = true }
+			)
+		end)
+		local childFiber = renderer.root:findByType(Foo):_currentFiber()
+		local tree = inspectHooks(childFiber)
+		expect(renderer:toJSON().props.Text).toBe("Context: <none>, Nothing Pending")
+		-- ROBLOX DEVIATION: This port exposes hook IDs with 1-based indexing.
+		-- React 17's HooksNode also lacks React 19's debugInfo and hookSource schema.
+		expect(tree).toEqual({
+			{
+				id = 1,
+				isStateEditable = true,
+				name = "State",
+				subHooks = {},
+				value = false,
+			},
+			{
+				id = 2,
+				isStateEditable = false,
+				name = "DeferredValue",
+				subHooks = {},
+				value = false,
+			},
+			{
+				id = 3,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "hello",
+			},
+			{
+				id = 4,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "not used",
+			},
+		})
+
+		act(function()
+			setShow(true)
+		end)
+
+		expect(renderer:toJSON().props.Text).toBe("Context: provided, Pending")
+		childFiber = renderer.root:findByType(Foo):_currentFiber()
+		tree = inspectHooks(childFiber)
+		expect(tree).toEqual({
+			{
+				id = 1,
+				isStateEditable = true,
+				name = "State",
+				subHooks = {},
+				value = true,
+			},
+			{
+				id = 2,
+				isStateEditable = false,
+				name = "DeferredValue",
+				subHooks = {},
+				value = false,
+			},
+			{
+				id = nil,
+				isStateEditable = false,
+				name = "Context",
+				subHooks = {},
+				value = "provided",
+			},
+			{
+				id = 3,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "hello",
+			},
+			{
+				id = 4,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "not used",
+			},
+		})
+
+		act(function()
+			unsuspend()
+		end)
+
+		expect(renderer:toJSON().props.Text).toBe(
+			"Context: <none>, Nothing Pending, Lazy"
+		)
+		childFiber = renderer.root:findByType(Foo):_currentFiber()
+		tree = inspectHooks(childFiber)
+		expect(tree).toEqual({
+			{
+				id = 1,
+				isStateEditable = true,
+				name = "State",
+				subHooks = {},
+				value = true,
+			},
+			{
+				id = 2,
+				isStateEditable = false,
+				name = "DeferredValue",
+				subHooks = {},
+				value = true,
+			},
+			{
+				id = 3,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "hello",
+			},
+			{
+				id = 4,
+				isStateEditable = false,
+				name = "Memo",
+				subHooks = {},
+				value = "not used",
+			},
+		})
+	end)
 	-- ROBLOX deviation START: unstable_useOpaqueIdentifier not implemented
 	-- it("should support composite useOpaqueIdentifier hook", function()
 	it.skip("should support composite useOpaqueIdentifier hook", function()

--- a/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberBeginWork.new.lua
@@ -1867,9 +1867,23 @@ local function shouldRemainOnFallback(
 	return hasSuspenseContext(suspenseContext, ForceSuspenseFallback)
 end
 
-local function getRemainingWorkInPrimaryTree(current: Fiber, renderLanes)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2324-L2342
+local function getRemainingWorkInPrimaryTree(
+	current: Fiber?,
+	primaryTreeDidDefer: boolean,
+	renderLanes
+)
 	-- TODO: Should not remove render lanes that were pinged during this render
-	return ReactFiberLane.removeLanes(current.childLanes, renderLanes)
+	local remainingLanes = if current == nil
+		then ReactFiberLane.NoLanes
+		else ReactFiberLane.removeLanes(current.childLanes, renderLanes)
+	if primaryTreeDidDefer then
+		remainingLanes = ReactFiberLane.mergeLanes(
+			remainingLanes,
+			ReactFiberWorkLoop.peekDeferredLane()
+		)
+	end
+	return remainingLanes
 end
 
 -- ROBLOX deviation: predeclare these methods to resolve method declaration ordering
@@ -1921,6 +1935,16 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 			end
 		end
 	end
+
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2368-L2371
+	-- ROBLOX DEVIATION: Use the module member directly because this file is at
+	-- Luau's local-register limit.
+	local didPrimaryChildrenDefer = bit32.band(
+		workInProgress.flags,
+		ReactFiberFlags.DidDefer
+	) ~= NoFlags
+	workInProgress.flags =
+		bit32.band(workInProgress.flags, bit32.bnot(ReactFiberFlags.DidDefer))
 
 	suspenseContext = setDefaultShallowSuspenseContext(suspenseContext)
 
@@ -1981,6 +2005,12 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 			)
 			local primaryChildFragment: Fiber = workInProgress.child :: any
 			primaryChildFragment.memoizedState = mountSuspenseOffscreenState(renderLanes)
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2430-L2438
+			primaryChildFragment.childLanes = getRemainingWorkInPrimaryTree(
+				current,
+				didPrimaryChildrenDefer,
+				renderLanes
+			)
 			workInProgress.memoizedState = SUSPENDED_MARKER
 			return fallbackFragment
 		elseif
@@ -1998,6 +2028,12 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 			)
 			local primaryChildFragment: Fiber = workInProgress.child :: any
 			primaryChildFragment.memoizedState = mountSuspenseOffscreenState(renderLanes)
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2474-L2482
+			primaryChildFragment.childLanes = getRemainingWorkInPrimaryTree(
+				current,
+				didPrimaryChildrenDefer,
+				renderLanes
+			)
 			workInProgress.memoizedState = SUSPENDED_MARKER
 
 			-- Since nothing actually suspended, there will nothing to ping this to
@@ -2067,6 +2103,12 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 						local primaryChildFragment: Fiber = workInProgress.child :: any
 						primaryChildFragment.memoizedState =
 							mountSuspenseOffscreenState(renderLanes)
+						-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L3153-L3161
+						primaryChildFragment.childLanes = getRemainingWorkInPrimaryTree(
+							current,
+							didPrimaryChildrenDefer,
+							renderLanes
+						)
 						workInProgress.memoizedState = SUSPENDED_MARKER
 						return fallbackChildFragment
 					end
@@ -2098,8 +2140,12 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 					)
 				end
 
-				primaryChildFragment.childLanes =
-					getRemainingWorkInPrimaryTree(current, renderLanes)
+				-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2577-L2582
+				primaryChildFragment.childLanes = getRemainingWorkInPrimaryTree(
+					current,
+					didPrimaryChildrenDefer,
+					renderLanes
+				)
 				workInProgress.memoizedState = SUSPENDED_MARKER
 				return fallbackChildFragment
 			else
@@ -2141,8 +2187,12 @@ local function updateSuspenseComponent(current, workInProgress, renderLanes)
 					)
 				end
 
-				primaryChildFragment.childLanes =
-					getRemainingWorkInPrimaryTree(current, renderLanes)
+				-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2577-L2582
+				primaryChildFragment.childLanes = getRemainingWorkInPrimaryTree(
+					current,
+					didPrimaryChildrenDefer,
+					renderLanes
+				)
 				-- Skip the primary children, and continue working on the
 				-- fallback children.
 				workInProgress.memoizedState = SUSPENDED_MARKER

--- a/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
+++ b/modules/react-reconciler/src/ReactFiberClassComponent.new.lua
@@ -75,6 +75,7 @@ local ReplaceState = ReactUpdateQueue.ReplaceState
 local ForceUpdate = ReactUpdateQueue.ForceUpdate
 local initializeUpdateQueue = ReactUpdateQueue.initializeUpdateQueue
 local cloneUpdateQueue = ReactUpdateQueue.cloneUpdateQueue
+local entangleTransitions = ReactUpdateQueue.entangleTransitions
 local NoLanes = ReactFiberLane.NoLanes
 
 local ReactFiberContext = require(script.Parent["ReactFiberContext.new"])
@@ -267,7 +268,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then
@@ -299,7 +303,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then
@@ -330,7 +337,10 @@ local function initializeClassComponentUpdater()
 			end
 
 			enqueueUpdate(fiber, update)
-			scheduleUpdateOnFiber(fiber, lane, eventTime)
+			local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+			if root ~= nil then
+				entangleTransitions(root, fiber, lane)
+			end
 
 			if __DEV__ then
 				if enableDebugTracing then

--- a/modules/react-reconciler/src/ReactFiberFlags.lua
+++ b/modules/react-reconciler/src/ReactFiberFlags.lua
@@ -30,6 +30,10 @@ exports.Deletion = --[[                     ]]
 	0b000000000000001000
 exports.ContentReset = --[[                 ]]
 	0b000000000000010000
+-- ROBLOX upstream: https://github.com/facebook/react/blob/61cde7820e72fa6e922de2434988fcbdc971710b/packages/react-reconciler/src/ReactFiberFlags.js#L44
+-- ROBLOX DEVIATION: This reuses ContentReset because host and Suspense fibers
+-- cannot interpret the same flag during one begin-work path.
+exports.DidDefer = exports.ContentReset
 exports.Callback = --[[                     ]]
 	0b000000000000100000
 exports.DidCapture = --[[                   ]]

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -82,7 +82,7 @@ local removeLanes = ReactFiberLane.removeLanes
 local markRootEntangled = ReactFiberLane.markRootEntangled
 local markRootMutableRead = ReactFiberLane.markRootMutableRead
 local includesOnlyNonUrgentLanes = ReactFiberLane.includesOnlyNonUrgentLanes
-local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
+local includesDeferredLane = ReactFiberLane.includesDeferredLane
 local isTransitionLane = ReactFiberLane.isTransitionLane
 -- local DefaultLanePriority = ReactFiberLane.DefaultLanePriority
 local ReactFiberNewContext = require(script.Parent["ReactFiberNewContext.new"])
@@ -97,6 +97,7 @@ local HookHasEffect = ReactHookEffectTags.HasEffect
 local HookLayout = ReactHookEffectTags.Layout
 local HookPassive = ReactHookEffectTags.Passive
 local ReactFiberWorkLoop = require(script.Parent["ReactFiberWorkLoop.new"]) :: any
+local requestDeferredLane = ReactFiberWorkLoop.requestDeferredLane
 local warnIfNotCurrentlyActingUpdatesInDEV =
 	ReactFiberWorkLoop.warnIfNotCurrentlyActingUpdatesInDEV
 local scheduleUpdateOnFiber = ReactFiberWorkLoop.scheduleUpdateOnFiber
@@ -1576,25 +1577,46 @@ function updateMemo<T...>(nextCreate: () -> T..., deps: Array<any> | nil): ...an
 end
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/ReactFiberHooks.new.js#L1933-L2001
-local function mountDeferredValue<T>(value: T): T
-	local hook = mountWorkInProgressHook()
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L2963-L3080
+-- ROBLOX DEVIATION: React 17 has no spare DeferredLane discriminator or
+-- separate root and entangled render-lane sets. Reserved transition-deferred
+-- lanes identify renders spawned by this hook without leaking that identity
+-- through ordinary transition entanglement.
+local function mountDeferredValueImpl<T>(hook: Hook, value: T, initialValue: T?): T
+	-- ROBLOX DEVIATION: Luau cannot distinguish an omitted argument from explicit nil.
+	if initialValue ~= nil and not includesDeferredLane(renderLanes) then
+		hook.memoizedState = initialValue
+
+		local deferredLane = requestDeferredLane()
+		currentlyRenderingFiber.lanes =
+			mergeLanes(currentlyRenderingFiber.lanes, deferredLane)
+		markSkippedUpdateLanes(deferredLane)
+		hook.baseState = true
+
+		return initialValue
+	end
+
 	hook.memoizedState = value
 	return value
 end
 
+local function mountDeferredValue<T>(value: T, initialValue: T?): T
+	local hook = mountWorkInProgressHook()
+	return mountDeferredValueImpl(hook, value, initialValue)
+end
+
 local updateDeferredValueImpl
 
-local function updateDeferredValue<T>(value: T): T
+local function updateDeferredValue<T>(value: T, _initialValue: T?): T
 	local hook = updateWorkInProgressHook()
 	local prevValue: T = currentHook.memoizedState
 	return updateDeferredValueImpl(hook, prevValue, value)
 end
 
-local function rerenderDeferredValue<T>(value: T): T
+local function rerenderDeferredValue<T>(value: T, initialValue: T?): T
 	local hook = updateWorkInProgressHook()
 	if currentHook == nil then
-		hook.memoizedState = value
-		return value
+		return mountDeferredValueImpl(hook, value, initialValue)
 	else
 		local prevValue: T = currentHook.memoizedState
 		return updateDeferredValueImpl(hook, prevValue, value)
@@ -1602,15 +1624,20 @@ local function rerenderDeferredValue<T>(value: T): T
 end
 
 updateDeferredValueImpl = function<T>(hook: Hook, prevValue: T, value: T): T
+	if is(value, prevValue) then
+		return value
+	end
+
+	-- ROBLOX DEVIATION: Hidden-tree initial-value prerendering is omitted because
+	-- this branch has no React 19 hidden-context or Activity contract.
 	local shouldDeferValue = not includesOnlyNonUrgentLanes(renderLanes)
+		and not includesDeferredLane(renderLanes)
 	if shouldDeferValue then
-		if not is(value, prevValue) then
-			local deferredLane = claimNextTransitionLane()
-			currentlyRenderingFiber.lanes =
-				mergeLanes(currentlyRenderingFiber.lanes, deferredLane)
-			markSkippedUpdateLanes(deferredLane)
-			hook.baseState = true
-		end
+		local deferredLane = requestDeferredLane()
+		currentlyRenderingFiber.lanes =
+			mergeLanes(currentlyRenderingFiber.lanes, deferredLane)
+		markSkippedUpdateLanes(deferredLane)
+		hook.baseState = true
 		return prevValue
 	else
 		if hook.baseState then
@@ -2176,10 +2203,11 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4114-L4118
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			mountHookTypesDev()
-			return mountDeferredValue(value)
+			return mountDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -2325,10 +2353,11 @@ if __DEV__ then
 			updateHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4281-L4285
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			updateHookTypesDev()
-			return mountDeferredValue(value)
+			return mountDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -2473,10 +2502,11 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4448-L4452
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			updateHookTypesDev()
-			return updateDeferredValue(value)
+			return updateDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -2622,10 +2652,11 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4615-L4619
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			updateHookTypesDev()
-			return rerenderDeferredValue(value)
+			return rerenderDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -2782,11 +2813,12 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4797-L4802
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			warnInvalidHookAccess()
 			mountHookTypesDev()
-			return mountDeferredValue(value)
+			return mountDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -2947,11 +2979,12 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L4989-L4994
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			warnInvalidHookAccess()
 			updateHookTypesDev()
-			return updateDeferredValue(value)
+			return updateDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"
@@ -3112,11 +3145,12 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		useDeferredValue = function<T>(value: T): T
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L5181-L5186
+		useDeferredValue = function<T>(value: T, initialValue: T?): T
 			currentHookNameInDev = "useDeferredValue"
 			warnInvalidHookAccess()
 			updateHookTypesDev()
-			return rerenderDeferredValue(value)
+			return rerenderDeferredValue(value, initialValue)
 		end,
 		useTransition = function(): (boolean, StartTransition)
 			currentHookNameInDev = "useTransition"

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -45,6 +45,8 @@ type MutableSourceSubscribeFn<Source, Snapshot> = ReactTypes.MutableSourceSubscr
 	Source,
 	Snapshot
 >
+type StartTransition = ReactTypes.StartTransition
+type StartTransitionOptions = ReactTypes.StartTransitionOptions
 
 local ReactInternalTypes = require(script.Parent.ReactInternalTypes)
 type Fiber = ReactInternalTypes.Fiber
@@ -73,15 +75,12 @@ local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffect
 local DebugTracingMode = require(script.Parent.ReactTypeOfMode).DebugTracingMode
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
-local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
+local intersectLanes = ReactFiberLane.intersectLanes
 local removeLanes = ReactFiberLane.removeLanes
 local markRootEntangled = ReactFiberLane.markRootEntangled
 local markRootMutableRead = ReactFiberLane.markRootMutableRead
-local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
-local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
-local higherLanePriority = ReactFiberLane.higherLanePriority
 local includesOnlyNonUrgentLanes = ReactFiberLane.includesOnlyNonUrgentLanes
 local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
 local isTransitionLane = ReactFiberLane.isTransitionLane
@@ -123,12 +122,11 @@ local function is(x: any, y: any)
 end
 local markWorkInProgressReceivedUpdate =
 	require(script.Parent["ReactFiberBeginWork.new"]).markWorkInProgressReceivedUpdate :: any
--- local {
---   UserBlockingPriority,
---   NormalPriority,
---   runWithPriority,
---   getCurrentPriorityLevel,
--- } = require(script.Parent.SchedulerWithReactIntegration.new)
+local SchedulerWithReactIntegration =
+	require(script.Parent["SchedulerWithReactIntegration.new"])
+local UserBlockingPriority = SchedulerWithReactIntegration.UserBlockingPriority
+local getCurrentPriorityLevel = SchedulerWithReactIntegration.getCurrentPriorityLevel
+local runWithPriority = SchedulerWithReactIntegration.runWithPriority
 local getIsHydrating =
 	require(script.Parent["ReactFiberHydrationContext.new"]).getIsHydrating
 -- local {
@@ -209,10 +207,6 @@ export type FunctionComponentUpdateQueue = {
 type BasicStateAction<S> = ((S) -> S) | S
 
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 local exports: any = {}
 
@@ -1629,18 +1623,16 @@ updateDeferredValueImpl = function<T>(hook: Hook, prevValue: T, value: T): T
 end
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L1974-L2061
--- ROBLOX deviation: React 17 exposes update lane priorities instead of React 18 event priorities.
+-- ROBLOX deviation: React 17 selects update lanes from Scheduler priority.
 local function startTransition(
 	setPending: Dispatch<BasicStateAction<boolean>>,
 	callback: () -> (),
 	options: StartTransitionOptions?
 ): ()
-	local previousPriority = getCurrentUpdateLanePriority()
-	setCurrentUpdateLanePriority(
-		higherLanePriority(previousPriority, InputContinuousLanePriority)
-	)
-
-	setPending(true)
+	local pendingPriority = math.max(getCurrentPriorityLevel(), UserBlockingPriority)
+	runWithPriority(pendingPriority, function()
+		setPending(true)
+	end)
 
 	local prevTransition = ReactCurrentBatchConfig.transition
 	ReactCurrentBatchConfig.transition = {}
@@ -1661,7 +1653,6 @@ local function startTransition(
 		callback()
 	end)
 
-	setCurrentUpdateLanePriority(previousPriority)
 	ReactCurrentBatchConfig.transition = prevTransition
 
 	if __DEV__ and currentTransition._updatedFibers ~= nil then
@@ -1676,7 +1667,7 @@ local function startTransition(
 	end
 
 	if not ok then
-		error(result)
+		error(result, 0)
 	end
 end
 
@@ -1811,8 +1802,7 @@ local function entangleTransitionUpdate<S, A>(
 	lane: Lane
 ): ()
 	if isTransitionLane(lane) then
-		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
-		local queueLanes = bit32.band(queue.lanes, root.pendingLanes)
+		local queueLanes = intersectLanes(queue.lanes, root.pendingLanes)
 		local newQueueLanes = mergeLanes(queueLanes, lane)
 		queue.lanes = newQueueLanes
 		markRootEntangled(root, newQueueLanes)

--- a/modules/react-reconciler/src/ReactFiberHooks.new.lua
+++ b/modules/react-reconciler/src/ReactFiberHooks.new.lua
@@ -21,6 +21,7 @@ local LuauPolyfill = require(Packages.LuauPolyfill)
 local Array = LuauPolyfill.Array
 local Error = LuauPolyfill.Error
 local Object = LuauPolyfill.Object
+local Set = LuauPolyfill.Set
 
 local __DEV__ = ReactGlobals.__DEV__ :: boolean
 
@@ -65,22 +66,25 @@ local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
 local enableDebugTracing: boolean? = ReactFeatureFlags.enableDebugTracing
 local enableSchedulingProfiler: boolean? = ReactFeatureFlags.enableSchedulingProfiler
 local enableNewReconciler: boolean? = ReactFeatureFlags.enableNewReconciler
--- local decoupleUpdatePriorityFromScheduler = ReactFeatureFlags.decoupleUpdatePriorityFromScheduler
+local enableTransitionTracing: boolean = ReactFeatureFlags.enableTransitionTracing
 local enableDoubleInvokingEffects = ReactFeatureFlags.enableDoubleInvokingEffects
 
 -- local ReactTypeOfMode = require(script.Parent.ReactTypeOfMode)
 local DebugTracingMode = require(script.Parent.ReactTypeOfMode).DebugTracingMode
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
--- local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
+local InputContinuousLanePriority = ReactFiberLane.InputContinuousLanePriority
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
 local removeLanes = ReactFiberLane.removeLanes
 local markRootEntangled = ReactFiberLane.markRootEntangled
 local markRootMutableRead = ReactFiberLane.markRootMutableRead
--- local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
--- local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
--- local higherLanePriority = ReactFiberLane.higherLanePriority
+local getCurrentUpdateLanePriority = ReactFiberLane.getCurrentUpdateLanePriority
+local setCurrentUpdateLanePriority = ReactFiberLane.setCurrentUpdateLanePriority
+local higherLanePriority = ReactFiberLane.higherLanePriority
+local includesOnlyNonUrgentLanes = ReactFiberLane.includesOnlyNonUrgentLanes
+local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
+local isTransitionLane = ReactFiberLane.isTransitionLane
 -- local DefaultLanePriority = ReactFiberLane.DefaultLanePriority
 local ReactFiberNewContext = require(script.Parent["ReactFiberNewContext.new"])
 local readContext = ReactFiberNewContext.readContext
@@ -149,7 +153,7 @@ local markStateUpdateScheduled =
 	require(script.Parent.SchedulingProfiler).markStateUpdateScheduled
 
 local ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher
--- local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
+local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 local FFlagReactCleanQueueOnUpdateBailout =
 	require(Packages.SafeFlags).createGetFFlag("ReactCleanQueueOnUpdateBailout")()
@@ -168,6 +172,7 @@ type Update<S, A> = {
 
 type UpdateQueue<S, A> = {
 	pending: Update<S, A> | nil,
+	lanes: Lanes,
 	dispatch: ((A) -> ...any) | nil,
 	lastRenderedReducer: ((S, A) -> S) | nil,
 	lastRenderedState: S | nil,
@@ -204,6 +209,10 @@ export type FunctionComponentUpdateQueue = {
 type BasicStateAction<S> = ((S) -> S) | S
 
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 local exports: any = {}
 
@@ -651,6 +660,7 @@ function mountReducer<S, I, A>(
 
 	local queue: UpdateQueue<S, A> = {
 		pending = nil,
+		lanes = NoLanes,
 		dispatch = nil,
 		lastRenderedReducer = reducer,
 		lastRenderedState = initialState :: any,
@@ -717,6 +727,11 @@ function updateReducer<S, I, A>(
 		baseQueue = pendingQueue
 		current.baseQueue = baseQueue
 		queue.pending = nil
+	end
+
+	if baseQueue == nil then
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L902-L904
+		queue.lanes = NoLanes
 	end
 
 	if baseQueue ~= nil then
@@ -1113,6 +1128,7 @@ function useMutableSource<Source, Snapshot>(
 		-- including any interleaving updates that occur.
 		local newQueue = {
 			pending = nil,
+			lanes = NoLanes,
 			dispatch = nil,
 			lastRenderedReducer = basicStateReducer,
 			lastRenderedState = snapshot,
@@ -1185,6 +1201,7 @@ function mountState<S>(initialState: (() -> S) | S): (S, Dispatch<BasicStateActi
 	hook.memoizedState = hook.baseState
 	local queue: UpdateQueue<S, BasicStateAction<S>> = {
 		pending = nil,
+		lanes = NoLanes,
 		dispatch = nil,
 		lastRenderedReducer = nil, --basicStateReducer,
 		lastRenderedState = initialState :: any,
@@ -1564,134 +1581,128 @@ function updateMemo<T...>(nextCreate: () -> T..., deps: Array<any> | nil): ...an
 	return unpack(nextValue)
 end
 
--- function mountDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = mountState(value)
---   mountEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+-- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/ReactFiberHooks.new.js#L1933-L2001
+local function mountDeferredValue<T>(value: T): T
+	local hook = mountWorkInProgressHook()
+	hook.memoizedState = value
+	return value
+end
 
--- function updateDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = updateState(value)
---   updateEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+local updateDeferredValueImpl
 
--- function rerenderDeferredValue<T>(value: T): T {
---   local [prevValue, setValue] = rerenderState(value)
---   updateEffect(() => {
---     local prevTransition = ReactCurrentBatchConfig.transition
---     ReactCurrentBatchConfig.transition = 1
---     try {
---       setValue(value)
---     } finally {
---       ReactCurrentBatchConfig.transition = prevTransition
---     end
---   }, [value])
---   return prevValue
--- end
+local function updateDeferredValue<T>(value: T): T
+	local hook = updateWorkInProgressHook()
+	local prevValue: T = currentHook.memoizedState
+	return updateDeferredValueImpl(hook, prevValue, value)
+end
 
--- function startTransition(setPending, callback)
---   local priorityLevel = getCurrentPriorityLevel()
---   if decoupleUpdatePriorityFromScheduler)
---     local previousLanePriority = getCurrentUpdateLanePriority()
---     setCurrentUpdateLanePriority(
---       higherLanePriority(previousLanePriority, InputContinuousLanePriority),
---     )
+local function rerenderDeferredValue<T>(value: T): T
+	local hook = updateWorkInProgressHook()
+	if currentHook == nil then
+		hook.memoizedState = value
+		return value
+	else
+		local prevValue: T = currentHook.memoizedState
+		return updateDeferredValueImpl(hook, prevValue, value)
+	end
+end
 
---     runWithPriority(
---       priorityLevel < UserBlockingPriority
---         ? UserBlockingPriority
---         : priorityLevel,
---       () => {
---         setPending(true)
---       },
---     )
+updateDeferredValueImpl = function<T>(hook: Hook, prevValue: T, value: T): T
+	local shouldDeferValue = not includesOnlyNonUrgentLanes(renderLanes)
+	if shouldDeferValue then
+		if not is(value, prevValue) then
+			local deferredLane = claimNextTransitionLane()
+			currentlyRenderingFiber.lanes =
+				mergeLanes(currentlyRenderingFiber.lanes, deferredLane)
+			markSkippedUpdateLanes(deferredLane)
+			hook.baseState = true
+		end
+		return prevValue
+	else
+		if hook.baseState then
+			hook.baseState = false
+			markWorkInProgressReceivedUpdate()
+		end
+		hook.memoizedState = value
+		return value
+	end
+end
 
---     -- TODO: Can remove this. Was only necessary because we used to give
---     -- different behavior to transitions without a config object. Now they are
---     -- all treated the same.
---     setCurrentUpdateLanePriority(DefaultLanePriority)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L1974-L2061
+-- ROBLOX deviation: React 17 exposes update lane priorities instead of React 18 event priorities.
+local function startTransition(
+	setPending: Dispatch<BasicStateAction<boolean>>,
+	callback: () -> (),
+	options: StartTransitionOptions?
+): ()
+	local previousPriority = getCurrentUpdateLanePriority()
+	setCurrentUpdateLanePriority(
+		higherLanePriority(previousPriority, InputContinuousLanePriority)
+	)
 
---     runWithPriority(
---       priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
---       () => {
---         local prevTransition = ReactCurrentBatchConfig.transition
---         ReactCurrentBatchConfig.transition = 1
---         try {
---           setPending(false)
---           callback()
---         } finally {
---           if decoupleUpdatePriorityFromScheduler)
---             setCurrentUpdateLanePriority(previousLanePriority)
---           end
---           ReactCurrentBatchConfig.transition = prevTransition
---         end
---       },
---     )
---   } else {
---     runWithPriority(
---       priorityLevel < UserBlockingPriority
---         ? UserBlockingPriority
---         : priorityLevel,
---       () => {
---         setPending(true)
---       },
---     )
+	setPending(true)
 
---     runWithPriority(
---       priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
---       () => {
---         local prevTransition = ReactCurrentBatchConfig.transition
---         ReactCurrentBatchConfig.transition = 1
---         try {
---           setPending(false)
---           callback()
---         } finally {
---           ReactCurrentBatchConfig.transition = prevTransition
---         end
---       },
---     )
---   end
--- end
+	local prevTransition = ReactCurrentBatchConfig.transition
+	ReactCurrentBatchConfig.transition = {}
+	local currentTransition = ReactCurrentBatchConfig.transition
 
--- function mountTransition(): [(() => void) => void, boolean] {
---   local [isPending, setPending] = mountState(false)
---   -- The `start` method can be stored on a ref, since `setPending`
---   -- never changes.
---   local start = startTransition.bind(null, setPending)
---   mountRef(start)
---   return [start, isPending]
--- end
+	if enableTransitionTracing and options ~= nil and options.name ~= nil then
+		currentTransition.name = options.name
+		-- ROBLOX deviation: Transition tracing clocks are not available in React Lua.
+		currentTransition.startTime = -1
+	end
 
--- function updateTransition(): [(() => void) => void, boolean] {
---   local [isPending] = updateState(false)
---   local startRef = updateRef()
---   local start: (() => void) => void = (startRef.current: any)
---   return [start, isPending]
--- end
+	if __DEV__ then
+		currentTransition._updatedFibers = Set.new()
+	end
 
--- function rerenderTransition(): [(() => void) => void, boolean] {
---   local [isPending] = rerenderState(false)
---   local startRef = updateRef()
---   local start: (() => void) => void = (startRef.current: any)
---   return [start, isPending]
--- end
+	local ok, result = pcall(function()
+		setPending(false)
+		callback()
+	end)
+
+	setCurrentUpdateLanePriority(previousPriority)
+	ReactCurrentBatchConfig.transition = prevTransition
+
+	if __DEV__ and currentTransition._updatedFibers ~= nil then
+		if prevTransition == nil and currentTransition._updatedFibers.size > 10 then
+			console.warn(
+				"Detected a large number of updates inside startTransition. "
+					.. "If this is due to a subscription please re-write it to use React provided hooks. "
+					.. "Otherwise concurrent mode guarantees are off the table."
+			)
+		end
+		currentTransition._updatedFibers:clear()
+	end
+
+	if not ok then
+		error(result)
+	end
+end
+
+local function mountTransition(): (boolean, StartTransition)
+	local isPending, setPending = mountState(false)
+	local start: StartTransition = function(callback, options)
+		startTransition(setPending, callback, options)
+	end
+	local hook = mountWorkInProgressHook()
+	hook.memoizedState = start
+	return isPending, start
+end
+
+local function updateTransition(): (boolean, StartTransition)
+	local isPending = updateState(false)
+	local hook = updateWorkInProgressHook()
+	local start: StartTransition = hook.memoizedState
+	return isPending, start
+end
+
+local function rerenderTransition(): (boolean, StartTransition)
+	local isPending = rerenderState(false)
+	local hook = updateWorkInProgressHook()
+	local start: StartTransition = hook.memoizedState
+	return isPending, start
+end
 
 local isUpdatingOpaqueValueInRenderPhase = false
 exports.getIsUpdatingOpaqueValueInRenderPhaseInDEV = function(): boolean?
@@ -1791,6 +1802,21 @@ end
 function rerenderOpaqueIdentifier(): OpaqueIDType
 	local id, _ = rerenderState(nil)
 	return id
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberHooks.new.js#L2338-L2361
+local function entangleTransitionUpdate<S, A>(
+	root: FiberRoot,
+	queue: UpdateQueue<S, A>,
+	lane: Lane
+): ()
+	if isTransitionLane(lane) then
+		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
+		local queueLanes = bit32.band(queue.lanes, root.pendingLanes)
+		local newQueueLanes = mergeLanes(queueLanes, lane)
+		queue.lanes = newQueueLanes
+		markRootEntangled(root, newQueueLanes)
+	end
 end
 
 function dispatchAction<S, A>(fiber: Fiber, queue: UpdateQueue<S, A>, action: A, ...): ()
@@ -1906,7 +1932,10 @@ function dispatchAction<S, A>(fiber: Fiber, queue: UpdateQueue<S, A>, action: A,
 				warnIfNotCurrentlyActingUpdatesInDEV(fiber)
 			end
 		end
-		scheduleUpdateOnFiber(fiber, lane, eventTime)
+		local root = scheduleUpdateOnFiber(fiber, lane, eventTime)
+		if root ~= nil then
+			entangleTransitionUpdate(root, queue, lane)
+		end
 	end
 
 	if __DEV__ then
@@ -1940,8 +1969,8 @@ local ContextOnlyDispatcher: Dispatcher = {
 	useBinding = throwInvalidHookError :: any,
 	useState = throwInvalidHookError :: any,
 	useDebugValue = throwInvalidHookError :: any,
-	-- useDeferredValue = throwInvalidHookError,
-	-- useTransition = throwInvalidHookError,
+	useDeferredValue = throwInvalidHookError :: any,
+	useTransition = throwInvalidHookError :: any,
 	useMutableSource = throwInvalidHookError :: any,
 	useOpaqueIdentifier = throwInvalidHookError :: any,
 
@@ -1964,8 +1993,8 @@ local HooksDispatcherOnMount: Dispatcher = {
 	useBinding = mountBinding,
 	useState = mountState,
 	useDebugValue = mountDebugValue,
-	-- useDeferredValue = mountDeferredValue,
-	-- useTransition = mountTransition,
+	useDeferredValue = mountDeferredValue,
+	useTransition = mountTransition,
 	useMutableSource = mountMutableSource,
 	useOpaqueIdentifier = mountOpaqueIdentifier,
 
@@ -1987,8 +2016,8 @@ local HooksDispatcherOnUpdate: Dispatcher = {
 	useBinding = updateBinding,
 	useState = updateState,
 	useDebugValue = updateDebugValue,
-	-- useDeferredValue = updateDeferredValue,
-	-- useTransition = updateTransition,
+	useDeferredValue = updateDeferredValue,
+	useTransition = updateTransition,
 	useMutableSource = updateMutableSource,
 	useOpaqueIdentifier = updateOpaqueIdentifier,
 
@@ -2010,8 +2039,8 @@ local HooksDispatcherOnRerender: Dispatcher = {
 	useBinding = updateBinding,
 	useState = rerenderState,
 	useDebugValue = updateDebugValue,
-	-- useDeferredValue = rerenderDeferredValue,
-	-- useTransition = rerenderTransition,
+	useDeferredValue = rerenderDeferredValue,
+	useTransition = rerenderTransition,
 	useMutableSource = updateMutableSource,
 	useOpaqueIdentifier = rerenderOpaqueIdentifier,
 
@@ -2157,16 +2186,16 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       mountHookTypesDev()
-		--       return mountDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       mountHookTypesDev()
-		--       return mountTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			mountHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			mountHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2306,16 +2335,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return mountDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return mountTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2454,16 +2483,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return updateDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return updateTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return updateDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return updateTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2603,16 +2632,16 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       updateHookTypesDev()
-		--       return rerenderDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       updateHookTypesDev()
-		--       return rerenderTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			updateHookTypesDev()
+			return rerenderDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			updateHookTypesDev()
+			return rerenderTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2763,18 +2792,18 @@ if __DEV__ then
 			mountHookTypesDev()
 			return mountDebugValue(value, formatterFn)
 		end,
-		-- useDeferredValue<T>(value: T): T {
-		--   currentHookNameInDev = 'useDeferredValue'
-		--   warnInvalidHookAccess()
-		--   mountHookTypesDev()
-		--   return mountDeferredValue(value)
-		-- },
-		-- useTransition(): [(() => void) => void, boolean] {
-		--   currentHookNameInDev = 'useTransition'
-		--   warnInvalidHookAccess()
-		--   mountHookTypesDev()
-		--   return mountTransition()
-		-- },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			mountHookTypesDev()
+			return mountDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			mountHookTypesDev()
+			return mountTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -2928,18 +2957,18 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return updateDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return updateTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return updateDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return updateTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<
@@ -3093,18 +3122,18 @@ if __DEV__ then
 			updateHookTypesDev()
 			return updateDebugValue(value, formatterFn)
 		end,
-		--     useDeferredValue<T>(value: T): T {
-		--       currentHookNameInDev = 'useDeferredValue'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return rerenderDeferredValue(value)
-		--     },
-		--     useTransition(): [(() => void) => void, boolean] {
-		--       currentHookNameInDev = 'useTransition'
-		--       warnInvalidHookAccess()
-		--       updateHookTypesDev()
-		--       return rerenderTransition()
-		--     },
+		useDeferredValue = function<T>(value: T): T
+			currentHookNameInDev = "useDeferredValue"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return rerenderDeferredValue(value)
+		end,
+		useTransition = function(): (boolean, StartTransition)
+			currentHookNameInDev = "useTransition"
+			warnInvalidHookAccess()
+			updateHookTypesDev()
+			return rerenderTransition()
+		end,
 		useMutableSource = function<Source, Snapshot>(
 			source: MutableSource<Source>,
 			getSnapshot: MutableSourceGetSnapshotFn<

--- a/modules/react-reconciler/src/ReactFiberLane.lua
+++ b/modules/react-reconciler/src/ReactFiberLane.lua
@@ -111,9 +111,19 @@ exports.DefaultLanes = DefaultLanes
 
 local TransitionHydrationLane: Lane = --[[              ]]
 	0b0000000000000000001000000000000
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L61-L95
 local TransitionLanes: Lanes = --[[                     ]]
 	0b0000000001111111110000000000000
-local TransitionLane1: Lane = bit32.band(TransitionLanes, -TransitionLanes)
+local TransitionUpdateLanes: Lanes = --[[               ]]
+	0b0000000000011111110000000000000
+local TransitionDeferredLanes: Lanes = --[[             ]]
+	0b0000000001100000000000000000000
+-- ROBLOX DEVIATION: React 17 has nine transition bits. Seven retain their
+-- existing update allocation and the two highest bits form the smallest
+-- rotating deferred family that keeps overlapping deferred tasks distinct.
+local TransitionLane1: Lane = bit32.band(TransitionUpdateLanes, -TransitionUpdateLanes)
+local TransitionDeferredLane1: Lane =
+	bit32.band(TransitionDeferredLanes, -TransitionDeferredLanes)
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/422d102bd58ab16f93b6d84a2a25c759b6a1288f/packages/react-reconciler/src/ReactFiberLane.new.js#L58-L62
 -- ROBLOX deviation: React 17 has lane families for each urgent priority.
@@ -126,6 +136,19 @@ local UrgentLanes: Lanes = bit32.bor(
 	InputContinuousLanes,
 	DefaultHydrationLane,
 	DefaultLanes
+)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L113-L114
+-- ROBLOX DEVIATION: React 17 retains separate update-lane families and a
+-- SyncBatchedLane. Hydration lanes are intentionally absent, matching
+-- React 19's rule that spawned work entangles only with update lanes.
+local UpdateLanes: Lanes = bit32.bor(
+	SyncLane,
+	SyncBatchedLane,
+	InputDiscreteLanes,
+	InputContinuousLanes,
+	DefaultLanes,
+	TransitionUpdateLanes
 )
 
 local RetryLanes: Lanes = --[[                          ]]
@@ -210,10 +233,16 @@ local function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes
 		return_highestLanePriority = TransitionHydrationPriority
 		return TransitionHydrationLane
 	end
-	local transitionLanes = bit32.band(TransitionLanes, lanes)
+	local transitionLanes = bit32.band(TransitionUpdateLanes, lanes)
 	if transitionLanes ~= NoLanes then
 		return_highestLanePriority = TransitionPriority
 		return transitionLanes
+	end
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L199-L216
+	local deferredLanes = bit32.band(TransitionDeferredLanes, lanes)
+	if deferredLanes ~= NoLanes then
+		return_highestLanePriority = TransitionPriority
+		return deferredLanes
 	end
 	local retryLanes = bit32.band(RetryLanes, lanes)
 	if retryLanes ~= NoLanes then
@@ -375,6 +404,27 @@ local function getNextLanes(root: FiberRoot, wipLanes: Lanes): Lanes
 	nextLanes =
 		bit32.band(pendingLanes, bit32.lshift(getLowestPriorityLane(nextLanes), 1) - 1)
 
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L423-L470
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L2164-L2192
+	-- ROBLOX DEVIATION: React 17 collapses task lanes and entangled render lanes.
+	-- When a boundaryless parent and its spawned task ping together, restore the
+	-- deferred task identity so a fresh mount does not replay the initial preview.
+	local entangledLanes = root.entangledLanes
+	local pingedDeferredLanes =
+		bit32.band(pingedLanes, TransitionDeferredLanes, entangledLanes)
+	local selectedPingedLanes = bit32.band(nextLanes, pingedLanes)
+	if pingedDeferredLanes ~= NoLanes and selectedPingedLanes ~= NoLanes then
+		local entanglements = root.entanglements
+		while pingedDeferredLanes > 0 do
+			local index = pickArbitraryLaneIndex(pingedDeferredLanes)
+			local lane = bit32.lshift(1, index)
+			if bit32.band(entanglements[index], selectedPingedLanes) ~= NoLanes then
+				nextLanes = bit32.bor(nextLanes, lane)
+			end
+			pingedDeferredLanes = bit32.band(pingedDeferredLanes, bit32.bnot(lane))
+		end
+	end
+
 	-- // If we're already in the middle of a render, switching lanes will interrupt
 	-- // it and we'll lose our progress. We should only do this if the new lanes are
 	-- // higher priority.
@@ -411,7 +461,6 @@ local function getNextLanes(root: FiberRoot, wipLanes: Lanes): Lanes
 	-- // For those exceptions where entanglement is semantically important, like
 	-- // useMutableSource, we should ensure that there is no partial work at the
 	-- // time we apply the entanglement.
-	local entangledLanes = root.entangledLanes
 	if entangledLanes ~= NoLanes then
 		local entanglements = root.entanglements
 		local lanes = bit32.band(nextLanes, entangledLanes)
@@ -549,6 +598,14 @@ local function includesNonIdleWork(lanes: Lanes)
 end
 exports.includesNonIdleWork = includesNonIdleWork
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L90-L91
+-- ROBLOX DEVIATION: The reserved family replaces React 19's DeferredLane
+-- discriminator in this smaller React 17 lane model.
+local function includesDeferredLane(lanes: Lanes): boolean
+	return bit32.band(lanes, TransitionDeferredLanes) ~= NoLanes
+end
+exports.includesDeferredLane = includesDeferredLane
+
 local function includesOnlyRetries(lanes: Lanes)
 	return bit32.band(lanes, RetryLanes) == lanes
 end
@@ -603,7 +660,10 @@ local function findUpdateLane(lanePriority: LanePriority, wipLanes: Lanes): Lane
 		if lane == NoLane then
 			-- // If all the default lanes are already being worked on, look for a
 			-- // lane in the transition range.
-			lane = pickArbitraryLane(bit32.band(TransitionLanes, bit32.bnot(wipLanes)))
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L79-L90
+			-- ROBLOX DEVIATION: Ordinary updates cannot claim the reserved deferred family.
+			lane =
+				pickArbitraryLane(bit32.band(TransitionUpdateLanes, bit32.bnot(wipLanes)))
 			if lane == NoLane then
 				-- // All the transition lanes are taken, too. This should be very
 				-- // rare, but as a last resort, pick a default lane. This will have
@@ -634,18 +694,22 @@ exports.findUpdateLane = findUpdateLane
 
 -- // To ensure consistency across multiple updates in the same event, this should
 -- // be pure function, so that it always returns the same lane for given inputs.
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L79-L90
+-- ROBLOX DEVIATION: Keep React 17's allocator helper but exclude the reserved
+-- deferred family from ordinary transition updates.
 local function findTransitionLane(wipLanes: Lanes, pendingLanes: Lanes): Lane
 	-- // First look for lanes that are completely unclaimed, i.e. have no
 	-- // pending work.
-	local lane = pickArbitraryLane(bit32.band(TransitionLanes, bit32.bnot(pendingLanes)))
+	local lane =
+		pickArbitraryLane(bit32.band(TransitionUpdateLanes, bit32.bnot(pendingLanes)))
 	if lane == NoLane then
 		-- // If all lanes have pending work, look for a lane that isn't currently
 		-- // being worked on.
-		lane = pickArbitraryLane(bit32.band(TransitionLanes, bit32.bnot(wipLanes)))
+		lane = pickArbitraryLane(bit32.band(TransitionUpdateLanes, bit32.bnot(wipLanes)))
 		if lane == NoLane then
 			-- // If everything is being worked on, pick any lane. This has the
 			-- // effect of interrupting the current work-in-progress.
-			lane = pickArbitraryLane(TransitionLanes)
+			lane = pickArbitraryLane(TransitionUpdateLanes)
 		end
 	end
 	return lane
@@ -653,17 +717,32 @@ end
 exports.findTransitionLane = findTransitionLane
 
 -- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberLane.new.js#L491-L503
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L721-L730
+-- ROBLOX DEVIATION: Retain React 17's public allocator name.
 local nextTransitionLane: Lane = TransitionLane1
 
 local function claimNextTransitionLane(): Lane
 	local lane = nextTransitionLane
 	nextTransitionLane = bit32.lshift(nextTransitionLane, 1)
-	if bit32.band(nextTransitionLane, TransitionLanes) == NoLanes then
+	if bit32.band(nextTransitionLane, TransitionUpdateLanes) == NoLanes then
 		nextTransitionLane = TransitionLane1
 	end
 	return lane
 end
 exports.claimNextTransitionLane = claimNextTransitionLane
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L733-L740
+local nextTransitionDeferredLane: Lane = TransitionDeferredLane1
+
+local function claimNextTransitionDeferredLane(): Lane
+	local lane = nextTransitionDeferredLane
+	nextTransitionDeferredLane = bit32.lshift(nextTransitionDeferredLane, 1)
+	if bit32.band(nextTransitionDeferredLane, TransitionDeferredLanes) == NoLanes then
+		nextTransitionDeferredLane = TransitionDeferredLane1
+	end
+	return lane
+end
+exports.claimNextTransitionDeferredLane = claimNextTransitionDeferredLane
 
 -- // To ensure consistency across multiple updates in the same event, this should
 -- // be pure function, so that it always returns the same lane for given inputs.
@@ -850,7 +929,16 @@ local function markRootUpdated(root: FiberRoot, updateLane: Lane, eventTime: num
 end
 exports.markRootUpdated = markRootUpdated
 
-local function markRootSuspended(root: FiberRoot, suspendedLanes: Lanes)
+local markSpawnedDeferredLane
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L846-L886
+-- ROBLOX DEVIATION: React 17 has neither warm lanes nor didAttemptEntireTree
+-- prewarming state, so only spawned-lane bookkeeping is added here.
+local function markRootSuspended(
+	root: FiberRoot,
+	suspendedLanes: Lanes,
+	spawnedLane: Lane
+)
 	root.suspendedLanes = bit32.bor(root.suspendedLanes, suspendedLanes)
 	root.pingedLanes = bit32.band(root.pingedLanes, bit32.bnot(suspendedLanes))
 
@@ -864,6 +952,10 @@ local function markRootSuspended(root: FiberRoot, suspendedLanes: Lanes)
 		expirationTimes[index] = NoTimestamp
 
 		lanes = bit32.band(lanes, bit32.bnot(lane))
+	end
+
+	if spawnedLane ~= NoLane then
+		markSpawnedDeferredLane(root, spawnedLane, suspendedLanes)
 	end
 end
 exports.markRootSuspended = markRootSuspended
@@ -897,7 +989,10 @@ local function markRootMutableRead(root: FiberRoot, updateLane: Lane)
 end
 exports.markRootMutableRead = markRootMutableRead
 
-local function markRootFinished(root: FiberRoot, remainingLanes: Lanes)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L889-L989
+-- ROBLOX DEVIATION: Retain React 17's smaller root-lane state shape while
+-- threading the spawned lane through its existing finished-work cleanup.
+local function markRootFinished(root: FiberRoot, remainingLanes: Lanes, spawnedLane: Lane)
 	local noLongerPendingLanes = bit32.band(root.pendingLanes, bit32.bnot(remainingLanes))
 
 	root.pendingLanes = remainingLanes
@@ -927,8 +1022,35 @@ local function markRootFinished(root: FiberRoot, remainingLanes: Lanes)
 
 		lanes = bit32.band(lanes, bit32.bnot(lane))
 	end
+
+	if spawnedLane ~= NoLane then
+		markSpawnedDeferredLane(root, spawnedLane, NoLanes)
+	end
 end
 exports.markRootFinished = markRootFinished
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L991-L1020
+-- ROBLOX DEVIATION: The reserved transition-deferred family itself replaces
+-- React 19's extra DeferredLane discriminator. Only suspended parent update
+-- lanes need entanglement; a completed parent leaves the spawned lane pending
+-- independently.
+markSpawnedDeferredLane = function(
+	root: FiberRoot,
+	spawnedLane: Lane,
+	entangledLanes: Lanes
+)
+	root.pendingLanes = bit32.bor(root.pendingLanes, spawnedLane)
+	root.suspendedLanes = bit32.band(root.suspendedLanes, bit32.bnot(spawnedLane))
+
+	if entangledLanes ~= NoLanes then
+		local spawnedLaneIndex = 31 - bit32.countlz(spawnedLane)
+		root.entangledLanes = bit32.bor(root.entangledLanes, spawnedLane)
+		root.entanglements[spawnedLaneIndex] = bit32.bor(
+			root.entanglements[spawnedLaneIndex],
+			bit32.band(entangledLanes, UpdateLanes)
+		)
+	end
+end
 
 local function markRootEntangled(root: FiberRoot, entangledLanes: Lanes)
 	local rootEntangledLanes = bit32.bor(root.entangledLanes, entangledLanes)

--- a/modules/react-reconciler/src/ReactFiberLane.lua
+++ b/modules/react-reconciler/src/ReactFiberLane.lua
@@ -113,6 +113,20 @@ local TransitionHydrationLane: Lane = --[[              ]]
 	0b0000000000000000001000000000000
 local TransitionLanes: Lanes = --[[                     ]]
 	0b0000000001111111110000000000000
+local TransitionLane1: Lane = bit32.band(TransitionLanes, -TransitionLanes)
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/422d102bd58ab16f93b6d84a2a25c759b6a1288f/packages/react-reconciler/src/ReactFiberLane.new.js#L58-L62
+-- ROBLOX deviation: React 17 has lane families for each urgent priority.
+local UrgentLanes: Lanes = bit32.bor(
+	SyncLane,
+	SyncBatchedLane,
+	InputDiscreteHydrationLane,
+	InputDiscreteLanes,
+	InputContinuousHydrationLane,
+	InputContinuousLanes,
+	DefaultHydrationLane,
+	DefaultLanes
+)
 
 local RetryLanes: Lanes = --[[                          ]]
 	0b0000011110000000000000000000000
@@ -545,6 +559,17 @@ local function includesOnlyTransitions(lanes: Lanes)
 end
 exports.includesOnlyTransitions = includesOnlyTransitions
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/422d102bd58ab16f93b6d84a2a25c759b6a1288f/packages/react-reconciler/src/ReactFiberLane.new.js#L527-L531
+local function includesOnlyNonUrgentLanes(lanes: Lanes): boolean
+	return bit32.band(lanes, UrgentLanes) == NoLanes
+end
+exports.includesOnlyNonUrgentLanes = includesOnlyNonUrgentLanes
+
+local function isTransitionLane(lane: Lane): boolean
+	return bit32.band(lane, TransitionLanes) ~= NoLanes
+end
+exports.isTransitionLane = isTransitionLane
+
 -- deviation: pre-declare pickArbitraryLane to keep ordering
 local pickArbitraryLane
 
@@ -588,7 +613,7 @@ local function findUpdateLane(lanePriority: LanePriority, wipLanes: Lanes): Lane
 		end
 		return lane
 	elseif
-		lanePriority == TransitionPriority -- // Should be handled by findTransitionLane instead
+		lanePriority == TransitionPriority -- // Should be handled by claimNextTransitionLane instead
 		or lanePriority == RetryLanePriority -- // Should be handled by findRetryLane instead
 	then
 		-- break
@@ -626,6 +651,19 @@ local function findTransitionLane(wipLanes: Lanes, pendingLanes: Lanes): Lane
 	return lane
 end
 exports.findTransitionLane = findTransitionLane
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberLane.new.js#L491-L503
+local nextTransitionLane: Lane = TransitionLane1
+
+local function claimNextTransitionLane(): Lane
+	local lane = nextTransitionLane
+	nextTransitionLane = bit32.lshift(nextTransitionLane, 1)
+	if bit32.band(nextTransitionLane, TransitionLanes) == NoLanes then
+		nextTransitionLane = TransitionLane1
+	end
+	return lane
+end
+exports.claimNextTransitionLane = claimNextTransitionLane
 
 -- // To ensure consistency across multiple updates in the same event, this should
 -- // be pure function, so that it always returns the same lane for given inputs.

--- a/modules/react-reconciler/src/ReactFiberLane.lua
+++ b/modules/react-reconciler/src/ReactFiberLane.lua
@@ -733,6 +733,11 @@ exports.mergeLanes = (
 	if FFlagReactInlineMergeLanes then bit32.bor else mergeLanes
 ) :: MergeLanes
 
+local function intersectLanes(a: Lanes, b: Lanes): Lanes
+	return bit32.band(a, b)
+end
+exports.intersectLanes = intersectLanes
+
 local function removeLanes(set: Lanes, subset: Lanes | Lane): Lanes
 	return bit32.band(set, bit32.bnot(subset))
 end
@@ -926,15 +931,21 @@ end
 exports.markRootFinished = markRootFinished
 
 local function markRootEntangled(root: FiberRoot, entangledLanes: Lanes)
-	root.entangledLanes = bit32.bor(root.entangledLanes, entangledLanes)
+	local rootEntangledLanes = bit32.bor(root.entangledLanes, entangledLanes)
+	root.entangledLanes = rootEntangledLanes
 
 	local entanglements = root.entanglements
-	local lanes = entangledLanes
+	local lanes = rootEntangledLanes
 	while lanes > 0 do
 		local index = pickArbitraryLaneIndex(lanes)
 		local lane = bit32.lshift(1, index)
 
-		entanglements[index] = bit32.bor(entanglements[index], entangledLanes)
+		if
+			bit32.band(lane, entangledLanes) ~= NoLanes
+			or bit32.band(entanglements[index], entangledLanes) ~= NoLanes
+		then
+			entanglements[index] = bit32.bor(entanglements[index], entangledLanes)
+		end
 
 		lanes = bit32.band(lanes, bit32.bnot(lane))
 	end

--- a/modules/react-reconciler/src/ReactFiberReconciler.new.lua
+++ b/modules/react-reconciler/src/ReactFiberReconciler.new.lua
@@ -101,6 +101,7 @@ local act = ReactFiberWorkLoop.act :: (() -> ()) -> ()
 local ReactUpdateQueue = require(script.Parent["ReactUpdateQueue.new"])
 local createUpdate = ReactUpdateQueue.createUpdate
 local enqueueUpdate = ReactUpdateQueue.enqueueUpdate
+local entangleTransitions = ReactUpdateQueue.entangleTransitions
 local ReactCurrentFiber = require(script.Parent.ReactCurrentFiber)
 local ReactCurrentFiberIsRendering = ReactCurrentFiber.isRendering
 -- deviation: this property would be captured as values instead of bound
@@ -376,7 +377,10 @@ exports.updateContainer = function(
 	end
 
 	enqueueUpdate(current, update)
-	scheduleUpdateOnFiber(current, lane, eventTime)
+	local root = scheduleUpdateOnFiber(current, lane, eventTime)
+	if root ~= nil then
+		entangleTransitions(root, current, lane)
+	end
 
 	return lane
 end

--- a/modules/react-reconciler/src/ReactFiberThrow.new.lua
+++ b/modules/react-reconciler/src/ReactFiberThrow.new.lua
@@ -27,6 +27,7 @@ type ReactPriorityLevel = ReactInternalTypes.ReactPriorityLevel
 local ReactFiberLane = require(script.Parent.ReactFiberLane)
 type Lanes = ReactFiberLane.Lanes
 type Lane = ReactFiberLane.Lane
+local ConcurrentRoot = require(script.Parent.ReactRootTags).ConcurrentRoot
 local ReactCapturedValue = require(script.Parent.ReactCapturedValue)
 type CapturedValue<T> = ReactCapturedValue.CapturedValue<T>
 local ReactUpdateQueue = require(script.Parent["ReactUpdateQueue.new"])
@@ -258,7 +259,8 @@ function throwException(
 	value: any,
 	rootRenderLanes: Lanes,
 	onUncaughtError,
-	renderDidError
+	renderDidError,
+	renderDidSuspendDelayIfPossible
 )
 	-- The source fiber did not complete.
 	sourceFiber.flags = bit32.bor(sourceFiber.flags, Incomplete)
@@ -427,7 +429,23 @@ function throwException(
 			workInProgress = workInProgress.return_ :: Fiber -- ROBLOX TODO: Luau narrowing doesn't understand this loop until nil pattern
 		until workInProgress == nil
 
-		-- No boundary was found. Fallthrough to error mode.
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThrow.js#L524-L537
+		-- Concurrent roots can suspend without a boundary and keep their current UI.
+		if root.tag == ConcurrentRoot then
+			local currentSource = sourceFiber.alternate
+			if currentSource ~= nil then
+				-- ROBLOX DEVIATION: The older work loop restores interrupted mounted
+				-- fibers here. A new mount has no alternate and retains its suspended hooks.
+				sourceFiber.updateQueue = currentSource.updateQueue
+				sourceFiber.memoizedState = currentSource.memoizedState
+				sourceFiber.lanes = currentSource.lanes
+			end
+			attachPingListener(root, wakeable, rootRenderLanes)
+			renderDidSuspendDelayIfPossible()
+			return
+		end
+
+		-- No boundary was found for a legacy root. Fallthrough to error mode.
 		-- TODO: Use invariant so the message is stripped in prod?
 		value = (getComponentName(sourceFiber.type) or "A React component")
 			.. " suspended while rendering, but no fallback UI was specified.\n"

--- a/modules/react-reconciler/src/ReactFiberTransition.lua
+++ b/modules/react-reconciler/src/ReactFiberTransition.lua
@@ -16,7 +16,6 @@ local ReactSharedInternals = require(Packages.Shared).ReactSharedInternals
 local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 return {
-	NoTransition = nil,
 	requestCurrentTransition = function(): { [any]: any }?
 		return ReactCurrentBatchConfig.transition
 	end,

--- a/modules/react-reconciler/src/ReactFiberTransition.lua
+++ b/modules/react-reconciler/src/ReactFiberTransition.lua
@@ -1,5 +1,5 @@
 --!strict
--- ROBLOX upstream: https://github.com/facebook/react/blob/ddd1faa1972b614dfbfae205f2aa4a6c0b39a759/packages/react-reconciler/src/ReactFiberTransition.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberTransition.js
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -16,8 +16,8 @@ local ReactSharedInternals = require(Packages.Shared).ReactSharedInternals
 local ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig
 
 return {
-	NoTransition = 0,
-	requestCurrentTransition = function(): number
+	NoTransition = nil,
+	requestCurrentTransition = function(): { [any]: any }?
 		return ReactCurrentBatchConfig.transition
 	end,
 }

--- a/modules/react-reconciler/src/ReactFiberUnwindWork.new.lua
+++ b/modules/react-reconciler/src/ReactFiberUnwindWork.new.lua
@@ -83,16 +83,20 @@ local function unwindWork(workInProgress: Fiber, renderLanes: Lanes): Fiber?
 		popTopLevelLegacyContextObject(workInProgress)
 		resetMutableSourceWorkInProgressVersions()
 		local flags = workInProgress.flags
-		invariant(
-			bit32.band(flags, ReactFiberFlags.DidCapture) == ReactFiberFlags.NoFlags,
-			"The root failed to unmount after an error. This is likely a bug in "
-				.. "React. Please file an issue."
-		)
-		workInProgress.flags = bit32.bor(
-			bit32.band(flags, bit32.bnot(ReactFiberFlags.ShouldCapture)),
-			ReactFiberFlags.DidCapture
-		)
-		return workInProgress
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberUnwindWork.js#L92-L115
+		if
+			bit32.band(flags, ReactFiberFlags.ShouldCapture)
+				~= ReactFiberFlags.NoFlags
+			and bit32.band(flags, ReactFiberFlags.DidCapture)
+				== ReactFiberFlags.NoFlags
+		then
+			workInProgress.flags = bit32.bor(
+				bit32.band(flags, bit32.bnot(ReactFiberFlags.ShouldCapture)),
+				ReactFiberFlags.DidCapture
+			)
+			return workInProgress
+		end
+		return nil
 	elseif workInProgress.tag == ReactWorkTags.HostComponent then
 		-- TODO: popHydrationState
 		popHostContext(workInProgress)

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -162,7 +162,7 @@ local SyncLane = ReactFiberLane.SyncLane
 local SyncBatchedLane = ReactFiberLane.SyncBatchedLane
 local NoTimestamp = ReactFiberLane.NoTimestamp
 local findUpdateLane = ReactFiberLane.findUpdateLane
-local findTransitionLane = ReactFiberLane.findTransitionLane
+local claimNextTransitionLane = ReactFiberLane.claimNextTransitionLane
 local findRetryLane = ReactFiberLane.findRetryLane
 local includesSomeLane = ReactFiberLane.includesSomeLane
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
@@ -413,8 +413,6 @@ local workInProgressRootUpdatedLanes: Lanes = ReactFiberLane.NoLanes
 -- Lanes that were pinged (in an interleaved event) during this render.
 local workInProgressRootPingedLanes: Lanes = ReactFiberLane.NoLanes
 
-local mostRecentlyUpdatedRoot: FiberRoot | nil = nil
-
 -- The most recent time we committed a fallback. This lets us ensure a train
 -- model where we don't commit new loading states in too quick succession.
 local globalMostRecentFallbackTime: number = 0
@@ -469,7 +467,8 @@ local spawnedWorkDuringRender: nil | Array<Lane | Lanes> = nil
 -- between the first and second call.
 local currentEventTime: number = NoTimestamp
 local currentEventWipLanes: Lanes = ReactFiberLane.NoLanes
-local currentEventPendingLanes: Lanes = ReactFiberLane.NoLanes
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L407-L408
+local currentEventTransitionLane: Lane = ReactFiberLane.NoLane
 
 local focusedInstanceHandle: nil | Fiber = nil
 local shouldFireAfterActiveInstanceBlur: boolean = false
@@ -539,22 +538,23 @@ exports.requestUpdateLane = function(fiber: Fiber): Lane
 	-- event. Then reset the cached values once we can be sure the event is over.
 	-- Our heuristic for that is whenever we enter a concurrent work loop.
 	--
-	-- We'll do the same for `currentEventPendingLanes` below.
 	if currentEventWipLanes == ReactFiberLane.NoLanes then
 		currentEventWipLanes = workInProgressRootIncludedLanes
 	end
 
-	local isTransition = ReactFiberTransition.requestCurrentTransition()
-		~= ReactFiberTransition.NoTransition
-	if isTransition then
-		if currentEventPendingLanes ~= ReactFiberLane.NoLanes then
-			if mostRecentlyUpdatedRoot ~= nil then
-				currentEventPendingLanes = mostRecentlyUpdatedRoot.pendingLanes
-			else
-				currentEventPendingLanes = ReactFiberLane.NoLanes
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L453-L476
+	local transition = ReactFiberTransition.requestCurrentTransition()
+	if transition ~= ReactFiberTransition.NoTransition then
+		if __DEV__ then
+			if transition._updatedFibers == nil then
+				transition._updatedFibers = Set.new()
 			end
+			transition._updatedFibers:add(fiber)
 		end
-		return findTransitionLane(currentEventWipLanes, currentEventPendingLanes)
+		if currentEventTransitionLane == ReactFiberLane.NoLane then
+			currentEventTransitionLane = claimNextTransitionLane()
+		end
+		return currentEventTransitionLane
 	end
 
 	-- TODO: Remove this dependency on the Scheduler priority.
@@ -723,12 +723,6 @@ exports.scheduleUpdateOnFiber = function(
 		mod.schedulePendingInteractions(root, lane)
 	end
 
-	-- We use this when assigning a lane for a transition inside
-	-- `requestUpdateLane`. We assume it's the same as the root being updated,
-	-- since in the common case of a single root app it probably is. If it's not
-	-- the same root, then it's not a huge deal, we just might batch more stuff
-	-- together more than necessary.
-	mostRecentlyUpdatedRoot = root
 	return root
 end
 
@@ -875,7 +869,7 @@ mod.performConcurrentWorkOnRoot = function(root): (() -> ...any) | nil
 	-- event time. The next update will compute a new event time.
 	currentEventTime = NoTimestamp
 	currentEventWipLanes = ReactFiberLane.NoLanes
-	currentEventPendingLanes = ReactFiberLane.NoLanes
+	currentEventTransitionLane = ReactFiberLane.NoLane
 
 	invariant(
 		bit32.band(executionContext, bit32.bor(RenderContext, CommitContext)) == NoContext,

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -411,6 +411,10 @@ local workInProgressRootSkippedLanes: (value: Lanes?) -> Lanes =
 local workInProgressRootUpdatedLanes: Lanes = ReactFiberLane.NoLanes
 -- Lanes that were pinged (in an interleaved event) during this render.
 local workInProgressRootPingedLanes: Lanes = ReactFiberLane.NoLanes
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L484-L486
+-- ROBLOX DEVIATION: Store this on the predeclared module table because this
+-- file is at Luau's top-level local limit.
+mod.workInProgressDeferredLane = ReactFiberLane.NoLane
 
 -- The most recent time we committed a fallback. This lets us ensure a train
 -- model where we don't commit new loading states in too quick succession.
@@ -625,6 +629,49 @@ function requestRetryLane(fiber: Fiber): Lane
 	return findRetryLane(currentEventWipLanes)
 end
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L852-L888
+exports.requestDeferredLane = function(): Lane
+	if mod.workInProgressDeferredLane == ReactFiberLane.NoLane then
+		-- Multiple useDeferredValue hooks rendered together should share a task.
+		-- ROBLOX DEVIATION: React 17 has no hydration path or dedicated Offscreen
+		-- prerender lane selection, so all deferred work uses the reserved family.
+		mod.workInProgressDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+	end
+
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberSuspenseContext.js#L20-L106
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/16654436039dd8f16a63928e71081c7745872e8f/packages/react-reconciler/src/ReactFiberThrow.new.js#L224-L235
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/1faf9e3dd5d6492f3607d5c721055819e4106bc6/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js#L65-L95
+	-- ROBLOX DEVIATION: React 17 has no identity-valued Suspense handler stack,
+	-- so reuse its throw-path capture selector on the current fiber's return path.
+	local suspenseContext = require(script.Parent["ReactFiberSuspenseContext.new"])
+	local hasInvisibleParentBoundary = suspenseContext.hasSuspenseContext(
+		suspenseContext.suspenseStackCursor.current,
+		suspenseContext.InvisibleParentSuspenseContext
+	)
+	local suspenseHandler = if workInProgress == nil then nil else workInProgress.return_
+	while suspenseHandler ~= nil do
+		if
+			suspenseHandler.tag == ReactWorkTags.SuspenseComponent
+			and ReactFiberSuspenseComponent.shouldCaptureSuspense(
+				suspenseHandler,
+				hasInvisibleParentBoundary
+			)
+		then
+			suspenseHandler.flags =
+				bit32.bor(suspenseHandler.flags, ReactFiberFlags.DidDefer)
+			break
+		end
+		suspenseHandler = suspenseHandler.return_
+	end
+
+	return mod.workInProgressDeferredLane
+end
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L912-L914
+exports.peekDeferredLane = function(): Lane
+	return mod.workInProgressDeferredLane
+end
+
 exports.scheduleUpdateOnFiber = function(
 	fiber: Fiber,
 	lane: Lane,
@@ -662,7 +709,12 @@ exports.scheduleUpdateOnFiber = function(
 			-- effect of interrupting the current render and switching to the update.
 			-- TODO: Make sure this doesn't override pings that happen while we've
 			-- already started rendering.
-			mod.markRootSuspended(root, workInProgressRootRenderLanes)
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1005-L1018
+			mod.markRootSuspended(
+				root,
+				workInProgressRootRenderLanes,
+				mod.workInProgressDeferredLane
+			)
 		end
 	end
 
@@ -941,7 +993,8 @@ mod.performConcurrentWorkOnRoot = function(root): (() -> ...any) | nil
 		if exitStatus == RootExitStatus.FatalErrored then
 			local fatalError = workInProgressRootFatalError
 			mod.prepareFreshStack(root, ReactFiberLane.NoLanes)
-			mod.markRootSuspended(root, lanes)
+			-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1232-L1237
+			mod.markRootSuspended(root, lanes, ReactFiberLane.NoLane)
 			ensureRootIsScheduled(root, now())
 			error(fatalError)
 		end
@@ -951,7 +1004,15 @@ mod.performConcurrentWorkOnRoot = function(root): (() -> ...any) | nil
 		local finishedWork: Fiber = root.current.alternate :: any
 		root.finishedWork = finishedWork
 		root.finishedLanes = lanes
-		mod.finishConcurrentRender(root, exitStatus, lanes)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1240-L1248
+		-- ROBLOX DEVIATION: React 17 explicitly threads the spawned lane into its
+		-- folded finish helper; modern React reads module state later.
+		mod.finishConcurrentRender(
+			root,
+			exitStatus,
+			lanes,
+			mod.workInProgressDeferredLane
+		)
 	end
 
 	ensureRootIsScheduled(root, now())
@@ -980,7 +1041,11 @@ function shouldForceFlushFallbacksInDEV()
 	return __DEV__ and actingUpdatesScopeDepth > 0
 end
 
-mod.finishConcurrentRender = function(root, exitStatus, lanes)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1342-L1497
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1499-L1615
+-- ROBLOX DEVIATION: This React 17 helper folds finishConcurrentRender and
+-- commitRootWhenReady together and receives spawnedLane explicitly.
+mod.finishConcurrentRender = function(root, exitStatus, lanes, spawnedLane)
 	if
 		exitStatus == RootExitStatus.Incomplete
 		or exitStatus == RootExitStatus.FatalErrored
@@ -992,9 +1057,9 @@ mod.finishConcurrentRender = function(root, exitStatus, lanes)
 	elseif exitStatus == RootExitStatus.Errored then
 		-- We should have already attempted to retry this tree. If we reached
 		-- this point, it errored again. Commit it.
-		mod.commitRoot(root)
+		mod.commitRoot(root, spawnedLane)
 	elseif exitStatus == RootExitStatus.Suspended then
-		mod.markRootSuspended(root, lanes)
+		mod.markRootSuspended(root, lanes, spawnedLane)
 
 		-- We have an acceptable loading state. We need to figure out if we
 		-- should immediately commit it or wait a bit.
@@ -1030,15 +1095,15 @@ mod.finishConcurrentRender = function(root, exitStatus, lanes)
 				-- lower priority work to do. Instead of committing the fallback
 				-- immediately, wait for more data to arrive.
 				root.timeoutHandle = ReactFiberHostConfig.scheduleTimeout(function()
-					return mod.commitRoot(root)
+					return mod.commitRoot(root, spawnedLane)
 				end, msUntilTimeout)
 				return
 			end
 		end
 		-- The work expired. Commit immediately.
-		mod.commitRoot(root)
+		mod.commitRoot(root, spawnedLane)
 	elseif exitStatus == RootExitStatus.SuspendedWithDelay then
-		mod.markRootSuspended(root, lanes)
+		mod.markRootSuspended(root, lanes, spawnedLane)
 
 		if includesOnlyTransitions(lanes) then
 			-- This is a transition, so we should exit without committing a
@@ -1065,29 +1130,30 @@ mod.finishConcurrentRender = function(root, exitStatus, lanes)
 				-- Instead of committing the fallback immediately, wait for more data
 				-- to arrive.
 				root.timeoutHandle = ReactFiberHostConfig.scheduleTimeout(function()
-					return mod.commitRoot(root)
+					return mod.commitRoot(root, spawnedLane)
 				end, msUntilTimeout)
 				return
 			end
 		end
 		-- Commit the placeholder.
-		mod.commitRoot(root)
+		mod.commitRoot(root, spawnedLane)
 	elseif exitStatus == RootExitStatus.Completed then
 		-- The work completed. Ready to commit.
-		mod.commitRoot(root)
+		mod.commitRoot(root, spawnedLane)
 	else
 		invariant(false, "Unknown root exit status.")
 	end
 end
 
-mod.markRootSuspended = function(root, suspendedLanes)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1719-L1729
+mod.markRootSuspended = function(root, suspendedLanes, spawnedLane)
 	-- When suspending, we should always exclude lanes that were pinged or (more
 	-- rarely, since we try to avoid it) updated during the render phase.
 	-- TODO: Lol maybe there's a better way to factor this besides this
 	-- obnoxiously named function :)
 	suspendedLanes = removeLanes(suspendedLanes, workInProgressRootPingedLanes)
 	suspendedLanes = removeLanes(suspendedLanes, workInProgressRootUpdatedLanes)
-	ReactFiberLane.markRootSuspended(root, suspendedLanes)
+	ReactFiberLane.markRootSuspended(root, suspendedLanes, spawnedLane)
 end
 
 -- This is the entry point for synchronous tasks that don't go
@@ -1152,10 +1218,13 @@ mod.performSyncWorkOnRoot = function(root)
 		end
 	end
 
+	-- ROBLOX DEVIATION: React 17 retains a separate sync path that repeats the
+	-- shared spawned-lane finalization performed by modern React's work loop.
 	if exitStatus == RootExitStatus.FatalErrored then
 		local fatalError = workInProgressRootFatalError
 		mod.prepareFreshStack(root, ReactFiberLane.NoLanes)
-		mod.markRootSuspended(root, lanes)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1232-L1237
+		mod.markRootSuspended(root, lanes, ReactFiberLane.NoLane)
 		ensureRootIsScheduled(root, now())
 		error(fatalError)
 	end
@@ -1165,7 +1234,9 @@ mod.performSyncWorkOnRoot = function(root)
 	local finishedWork: Fiber = root.current.alternate :: any
 	root.finishedWork = finishedWork
 	root.finishedLanes = lanes
-	mod.commitRoot(root)
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L3416-L3424
+	-- ROBLOX DEVIATION: Thread spawnedLane through React 17's separate sync commit.
+	mod.commitRoot(root, mod.workInProgressDeferredLane)
 
 	-- Before exiting, make sure there's a callback scheduled for the next
 	-- pending level.
@@ -1592,6 +1663,8 @@ mod.prepareFreshStack = function(root: FiberRoot, lanes: Lanes)
 	workInProgressRootSkippedLanes(ReactFiberLane.NoLanes)
 	workInProgressRootUpdatedLanes = ReactFiberLane.NoLanes
 	workInProgressRootPingedLanes = ReactFiberLane.NoLanes
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L2170-L2180
+	mod.workInProgressDeferredLane = ReactFiberLane.NoLane
 
 	if ReactFeatureFlags.enableSchedulerTracing then
 		spawnedWorkDuringRender = nil
@@ -1651,7 +1724,7 @@ mod.handleError = function(root, thrownValue): ()
 				)
 			end
 
-			-- ROBLOX deviation, we pass in onUncaughtError and renderDidError here since throwException can't call them due to a require cycle
+			-- ROBLOX deviation, pass Work Loop callbacks since throwException can't call them due to a require cycle
 			throwException(
 				root,
 				(erroredWork :: Fiber).return_,
@@ -1659,7 +1732,8 @@ mod.handleError = function(root, thrownValue): ()
 				thrownValue,
 				workInProgressRootRenderLanes,
 				exports.onUncaughtError,
-				exports.renderDidError
+				exports.renderDidError,
+				exports.renderDidSuspendDelayIfPossible
 			)
 			mod.completeUnitOfWork(erroredWork)
 		end)
@@ -1755,7 +1829,12 @@ exports.renderDidSuspendDelayIfPossible = function(): ()
 		-- (inside this function), since by suspending at the end of the render
 		-- phase introduces a potential mistake where we suspend lanes that were
 		-- pinged or updated while we were rendering.
-		mod.markRootSuspended(workInProgressRoot, workInProgressRootRenderLanes)
+		-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1357-L1417
+		mod.markRootSuspended(
+			workInProgressRoot,
+			workInProgressRootRenderLanes,
+			mod.workInProgressDeferredLane
+		)
 	end
 end
 
@@ -2093,12 +2172,13 @@ mod.completeUnitOfWork = function(unitOfWork: Fiber)
 	end
 end
 
-mod.commitRoot = function(root)
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L3423-L3541
+mod.commitRoot = function(root, spawnedLane)
 	local renderPriorityLevel = getCurrentPriorityLevel()
 	runWithPriority(ImmediateSchedulerPriority, function()
 		-- ROBLOX deviation: RobloxReactProfiling
 		RobloxReactProfiling.profileCommitBefore()
-		local ret = mod.commitRootImpl(root, renderPriorityLevel)
+		local ret = mod.commitRootImpl(root, renderPriorityLevel, spawnedLane)
 		RobloxReactProfiling.profileCommitAfter()
 		return ret
 	end)
@@ -2106,7 +2186,7 @@ mod.commitRoot = function(root)
 end
 
 -- ROBLOX Luau FIXME: Luau doesn't infer root as FiberRoot via the callgraph from ensureRootIsScheduled(root: FiberRoot)
-mod.commitRootImpl = function(root: FiberRoot, renderPriorityLevel)
+mod.commitRootImpl = function(root: FiberRoot, renderPriorityLevel, spawnedLane)
 	repeat
 		-- `flushPassiveEffects` will call `flushSyncUpdateQueue` at the end, which
 		-- means `flushPassiveEffects` will sometimes result in additional
@@ -2167,7 +2247,7 @@ mod.commitRootImpl = function(root: FiberRoot, renderPriorityLevel)
 	-- Update the first and last pending times on this root. The new first
 	-- pending time is whatever is left on the root fiber.
 	local remainingLanes = mergeLanes(finishedWork.lanes, finishedWork.childLanes)
-	markRootFinished(root, remainingLanes)
+	markRootFinished(root, remainingLanes, spawnedLane)
 
 	-- Clear already finished discrete updates in case that a later call of
 	-- `flushDiscreteUpdates` starts a useless render pass which may cancels

--- a/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
+++ b/modules/react-reconciler/src/ReactFiberWorkLoop.new.lua
@@ -190,7 +190,6 @@ local lanePriorityToSchedulerPriority = ReactFiberLane.lanePriorityToSchedulerPr
 local ReactFiberTransition = require(script.Parent.ReactFiberTransition)
 -- deviation: Use properties directly instead of localizing to avoid 200 limit
 -- local requestCurrentTransition = ReactFiberTransition.requestCurrentTransition
--- local NoTransition = ReactFiberTransition.NoTransition
 
 local ReactFiberUnwindWork = require(script.Parent["ReactFiberUnwindWork.new"]) :: any
 local unwindWork = ReactFiberUnwindWork.unwindWork
@@ -544,7 +543,7 @@ exports.requestUpdateLane = function(fiber: Fiber): Lane
 
 	-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L453-L476
 	local transition = ReactFiberTransition.requestCurrentTransition()
-	if transition ~= ReactFiberTransition.NoTransition then
+	if transition ~= nil then
 		if __DEV__ then
 			if transition._updatedFibers == nil then
 				transition._updatedFibers = Set.new()

--- a/modules/react-reconciler/src/ReactInternalTypes.lua
+++ b/modules/react-reconciler/src/ReactInternalTypes.lua
@@ -71,6 +71,7 @@ export type Update<State> = {
 
 export type SharedQueue<State> = {
 	pending: Update<State>?,
+	lanes: Lanes,
 }
 
 export type UpdateQueue<State> = {

--- a/modules/react-reconciler/src/ReactUpdateQueue.new.lua
+++ b/modules/react-reconciler/src/ReactUpdateQueue.new.lua
@@ -107,6 +107,8 @@ local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
 local mergeLanes = ReactFiberLane.mergeLanes
+local isTransitionLane = ReactFiberLane.isTransitionLane
+local markRootEntangled = ReactFiberLane.markRootEntangled
 
 -- ROBLOX deviation: lazy instantiate to avoid circular require
 local ReactFiberNewContext --= require(script.Parent["ReactFiberNewContext.new"])
@@ -206,6 +208,7 @@ local function initializeUpdateQueue<State>(fiber: Fiber): ()
 		lastBaseUpdate = nil,
 		shared = {
 			pending = nil,
+			lanes = NoLanes,
 		},
 		effects = nil,
 	}
@@ -308,6 +311,24 @@ local function enqueueUpdate<State>(fiber: Fiber, update: Update<State>)
 	end
 end
 exports.enqueueUpdate = enqueueUpdate
+
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/ReactUpdateQueue.new.js#L566-L594
+local function entangleTransitions(root: FiberRoot, fiber: Fiber, lane: Lane): ()
+	local updateQueue = fiber.updateQueue
+	if updateQueue == nil then
+		return
+	end
+
+	local sharedQueue: SharedQueue<any> = (updateQueue :: any).shared
+	if isTransitionLane(lane) then
+		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
+		local queueLanes = bit32.band(sharedQueue.lanes, root.pendingLanes)
+		local newQueueLanes = mergeLanes(queueLanes, lane)
+		sharedQueue.lanes = newQueueLanes
+		markRootEntangled(root, newQueueLanes)
+	end
+end
+exports.entangleTransitions = entangleTransitions
 
 local function enqueueCapturedUpdate<State>(workInProgress: Fiber, capturedUpdate: Update<State>)
 	-- Captured updates are updates that are thrown by a child during the render

--- a/modules/react-reconciler/src/ReactUpdateQueue.new.lua
+++ b/modules/react-reconciler/src/ReactUpdateQueue.new.lua
@@ -99,10 +99,12 @@ local console = require(Packages.Shared).console
 
 local ReactInternalTypes = require(script.Parent.ReactInternalTypes)
 type Fiber = ReactInternalTypes.Fiber
+type FiberRoot = ReactInternalTypes.FiberRoot
 type Lane = ReactInternalTypes.Lane
 type Lanes = ReactInternalTypes.Lanes
 
 local ReactFiberLane = require(script.Parent.ReactFiberLane)
+local intersectLanes = ReactFiberLane.intersectLanes
 local NoLane = ReactFiberLane.NoLane
 local NoLanes = ReactFiberLane.NoLanes
 local isSubsetOfLanes = ReactFiberLane.isSubsetOfLanes
@@ -321,8 +323,7 @@ local function entangleTransitions(root: FiberRoot, fiber: Fiber, lane: Lane): (
 
 	local sharedQueue: SharedQueue<any> = (updateQueue :: any).shared
 	if isTransitionLane(lane) then
-		-- ROBLOX deviation: inline intersectLanes because the React 17 lane module does not export it.
-		local queueLanes = bit32.band(sharedQueue.lanes, root.pendingLanes)
+		local queueLanes = intersectLanes(sharedQueue.lanes, root.pendingLanes)
 		local newQueueLanes = mergeLanes(queueLanes, lane)
 		sharedQueue.lanes = newQueueLanes
 		markRootEntangled(root, newQueueLanes)

--- a/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
@@ -1,0 +1,176 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+]]
+
+local Packages = script.Parent.Parent.Parent
+local React
+local ReactNoop
+local Scheduler
+local startTransition
+local useDeferredValue
+local useMemo
+local useState
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+
+local function renderedOutput(originalValue, deferredValue)
+	return React.createElement(
+		"div",
+		nil,
+		React.createElement("div", nil, "Original: " .. tostring(originalValue)),
+		React.createElement("div", nil, "Deferred: " .. tostring(deferredValue))
+	)
+end
+
+describe("ReactDeferredValue", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Scheduler)
+		startTransition = React.startTransition
+		useDeferredValue = React.useDeferredValue
+		useMemo = React.useMemo
+		useState = React.useState
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	local function createChildren(value, deferredValue)
+		local child = useMemo(function()
+			return React.createElement(Text, {
+				text = "Original: " .. tostring(value),
+			})
+		end, { value })
+		local deferredChild = useMemo(function()
+			return React.createElement(Text, {
+				text = "Deferred: " .. tostring(deferredValue),
+			})
+		end, { deferredValue })
+
+		return React.createElement(
+			"div",
+			nil,
+			React.createElement("div", nil, child),
+			React.createElement("div", nil, deferredChild)
+		)
+	end
+
+	local function runDeferredValueSequence(App)
+		local root = ReactNoop.createRoot()
+
+		ReactNoop.act(function()
+			root.render(React.createElement(App, { value = 1 }))
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "Original: 1", "Deferred: 1" })
+
+		ReactNoop.act(function()
+			root.render(React.createElement(App, { value = 2 }))
+			jestExpect(Scheduler).toFlushUntilNextPaint({ "Original: 2" })
+			jestExpect(Scheduler).toFlushUntilNextPaint({ "Deferred: 2" })
+		end)
+		jestExpect(root).toMatchRenderedOutput(renderedOutput(2, 2))
+
+		ReactNoop.act(function()
+			startTransition(function()
+				root.render(React.createElement(App, { value = 3 }))
+			end)
+			jestExpect(Scheduler).toFlushUntilNextPaint({
+				"Original: 3",
+				"Deferred: 3",
+			})
+		end)
+		jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 3))
+	end
+
+	it(
+		"does not cause an infinite defer loop if the original value isn't memoized",
+		function()
+			local function App(props)
+				local deferredObject = useDeferredValue({ value = props.value })
+				return createChildren(props.value, deferredObject.value)
+			end
+
+			runDeferredValueSequence(App)
+		end
+	)
+
+	it("does not defer during a transition", function()
+		local function App(props)
+			local deferredValue = useDeferredValue(props.value)
+			return createChildren(props.value, deferredValue)
+		end
+
+		runDeferredValueSequence(App)
+	end)
+
+	it("works if there's a render phase update", function()
+		local function App(props)
+			local value, setValue = useState(nil)
+			if value ~= props.value then
+				setValue(props.value)
+			end
+
+			local deferredValue = useDeferredValue(value)
+			return createChildren(value, deferredValue)
+		end
+
+		runDeferredValueSequence(App)
+	end)
+
+	it(
+		"regression test: during urgent update, reuse previous value, not initial value",
+		function()
+			local function App(props)
+				local value, setValue = useState(nil)
+				if value ~= props.value then
+					setValue(props.value)
+				end
+
+				local deferredValue = useDeferredValue(value)
+				return createChildren(value, deferredValue)
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App, { value = 1 }))
+				jestExpect(Scheduler).toFlushUntilNextPaint({
+					"Original: 1",
+					"Deferred: 1",
+				})
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(1, 1))
+			end)
+
+			ReactNoop.act(function()
+				startTransition(function()
+					root.render(React.createElement(App, { value = 2 }))
+				end)
+				jestExpect(Scheduler).toFlushUntilNextPaint({
+					"Original: 2",
+					"Deferred: 2",
+				})
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(2, 2))
+			end)
+
+			ReactNoop.act(function()
+				root.render(React.createElement(App, { value = 3 }))
+				jestExpect(Scheduler).toFlushUntilNextPaint({ "Original: 3" })
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 2))
+				jestExpect(Scheduler).toFlushUntilNextPaint({ "Deferred: 3" })
+				jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 3))
+			end)
+		end
+	)
+end)

--- a/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactDeferredValue.spec.lua
@@ -1,4 +1,8 @@
 -- ROBLOX upstream: https://github.com/facebook/react/blob/22edb9f777d27369fd2c1fad378f74e237b6dfd3/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js#L374-L697
+-- ROBLOX DEVIATION: React 17 does not implement React 19.2 sibling prewarming, so the corresponding duplicate suspension logs are omitted.
+-- ROBLOX DEVIATION: React 17's ReactNoop.act is synchronous; upstream async
+-- act and wait helpers translate to inline Scheduler flush matchers.
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -14,8 +18,11 @@ local startTransition
 local useDeferredValue
 local useMemo
 local useState
+local Suspense
+local textCache
 
 local JestGlobals = require(Packages.Dev.JestGlobals)
+local afterEach = JestGlobals.afterEach
 local beforeEach = JestGlobals.beforeEach
 local describe = JestGlobals.describe
 local it = JestGlobals.it
@@ -41,9 +48,67 @@ describe("ReactDeferredValue", function()
 		useDeferredValue = React.useDeferredValue
 		useMemo = React.useMemo
 		useState = React.useState
+		Suspense = React.Suspense
+		textCache = {}
 	end)
 
+	-- ROBLOX DEVIATION: Handler regressions flush React 17's JND timer; always
+	-- restore real timers, including when an assertion fails.
+	afterEach(function()
+		jest.useRealTimers()
+	end)
+
+	local function resolveText(text)
+		local record = textCache[text]
+		if record == nil then
+			textCache[text] = { status = "resolved", value = text }
+		elseif record.status == "pending" then
+			record.status = "resolved"
+			record.value = text
+			for _, ping in record.pings do
+				ping()
+			end
+		end
+	end
+
+	local function readText(text)
+		local record = textCache[text]
+		if record ~= nil then
+			if record.status == "pending" then
+				Scheduler.unstable_yieldValue("Suspend! [" .. text .. "]")
+				error(record.value)
+			elseif record.status == "rejected" then
+				error(record.value)
+			else
+				return record.value
+			end
+		end
+
+		Scheduler.unstable_yieldValue("Suspend! [" .. text .. "]")
+		local newRecord
+		local wakeable = {
+			-- ROBLOX DEVIATION: Luau thenables use andThen and invoke an already
+			-- resolved continuation synchronously in this test fixture.
+			andThen = function(_self, resolve)
+				if newRecord.status == "pending" then
+					table.insert(newRecord.pings, resolve)
+				else
+					resolve(newRecord.value)
+				end
+			end,
+		}
+		newRecord = { pings = {}, status = "pending", value = wakeable }
+		textCache[text] = newRecord
+		error(wakeable)
+	end
+
 	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	local function AsyncText(props)
+		readText(props.text)
 		Scheduler.unstable_yieldValue(props.text)
 		return props.text
 	end
@@ -171,6 +236,413 @@ describe("ReactDeferredValue", function()
 				jestExpect(Scheduler).toFlushUntilNextPaint({ "Deferred: 3" })
 				jestExpect(root).toMatchRenderedOutput(renderedOutput(3, 3))
 			end)
+		end
+	)
+
+	it("supports initialValue argument", function()
+		local function App()
+			local value = useDeferredValue("Final", "Initial")
+			return React.createElement(Text, { text = value })
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(App))
+			jestExpect(Scheduler).toFlushUntilNextPaint({ "Initial" })
+			jestExpect(root).toMatchRenderedOutput("Initial")
+		end)
+		jestExpect(Scheduler).toHaveYielded({ "Final" })
+		jestExpect(root).toMatchRenderedOutput("Final")
+	end)
+
+	it(
+		"defers during initial render when initialValue is provided, even if render is not sync",
+		function()
+			local function App()
+				local value = useDeferredValue("Final", "Initial")
+				return React.createElement(Text, { text = value })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				startTransition(function()
+					root.render(React.createElement(App))
+				end)
+				jestExpect(Scheduler).toFlushUntilNextPaint({ "Initial" })
+				jestExpect(root).toMatchRenderedOutput("Initial")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"if a suspended render spawns a deferred task, we can switch to the deferred task without finishing the original one (no Suspense boundary)",
+		function()
+			local function App()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Loading...]",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput(nil)
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			jestExpect(root).toMatchRenderedOutput("Final")
+
+			ReactNoop.act(function()
+				resolveText("Loading...")
+			end)
+			jestExpect(Scheduler).toHaveYielded({})
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"if a suspended render spawns a deferred task, we can switch to the deferred task without finishing the original one (no Suspense boundary, synchronous parent update)",
+		function()
+			local function App()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				ReactNoop.flushSync(function()
+					root.render(React.createElement(App))
+				end)
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Loading...]",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput(nil)
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			jestExpect(root).toMatchRenderedOutput("Final")
+
+			ReactNoop.act(function()
+				resolveText("Loading...")
+			end)
+			jestExpect(Scheduler).toHaveYielded({})
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"if a suspended render spawns a deferred task, we can switch to the deferred task without finishing the original one (Suspense boundary)",
+		function()
+			local function App()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(
+					React.createElement(
+						Suspense,
+						{ fallback = React.createElement(Text, { text = "Fallback" }) },
+						React.createElement(App)
+					)
+				)
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Loading...]",
+				"Fallback",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput("Fallback")
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			jestExpect(root).toMatchRenderedOutput("Final")
+
+			ReactNoop.act(function()
+				resolveText("Loading...")
+			end)
+			jestExpect(Scheduler).toHaveYielded({})
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L879-L886
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberSuspenseContext.js#L20-L106
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/16654436039dd8f16a63928e71081c7745872e8f/packages/react-reconciler/src/ReactFiberThrow.new.js#L224-L235
+	-- ROBLOX DEVIATION: These regressions verify the React 17 reconstruction of
+	-- the React 19 Suspense handler stack used by requestDeferredLane.
+	it(
+		"marks the outer Suspense boundary when a deferred value mounts in a fallback",
+		function()
+			jest.useFakeTimers()
+
+			local function InnerFallback()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(
+					React.createElement(
+						Suspense,
+						{
+							fallback = React.createElement(Text, {
+								text = "Outer Fallback",
+							}),
+						},
+						React.createElement(
+							Suspense,
+							{ fallback = React.createElement(InnerFallback) },
+							React.createElement(AsyncText, { text = "Primary" })
+						)
+					)
+				)
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Primary]",
+				"Suspend! [Loading...]",
+				"Outer Fallback",
+				"Suspend! [Primary]",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput("Outer Fallback")
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Primary]",
+				"Final",
+			})
+			-- ROBLOX DEVIATION: React 17's ReactNoop.act does not force this
+			-- Suspense recovery timer. PR #34 uses the same JND test adaptation.
+			jest.runOnlyPendingTimers()
+			jestExpect(Scheduler).toHaveYielded({})
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"marks a desirable outer Suspense boundary instead of an avoided fallback",
+		function()
+			jest.useFakeTimers()
+
+			local function App()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(
+					Suspense,
+					{
+						fallback = React.createElement(Text, {
+							text = "Outer Fallback",
+						}),
+					},
+					React.createElement(Suspense, {
+						fallback = React.createElement(Text, {
+							text = "Inner Fallback",
+						}),
+						unstable_avoidThisFallback = true,
+					}, React.createElement(App))
+				))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Loading...]",
+				"Outer Fallback",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput("Outer Fallback")
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			-- ROBLOX DEVIATION: React 17's ReactNoop.act does not force this
+			-- Suspense recovery timer. PR #34 uses the same JND test adaptation.
+			jest.runOnlyPendingTimers()
+			jestExpect(Scheduler).toHaveYielded({})
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"if a suspended render spawns a deferred task that also suspends, we can finish the original task if that one loads first",
+		function()
+			local function App()
+				local text = useDeferredValue("Final", "Loading...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Suspend! [Loading...]",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput(nil)
+
+			ReactNoop.act(function()
+				resolveText("Loading...")
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Loading...",
+				"Suspend! [Final]",
+			})
+			jestExpect(root).toMatchRenderedOutput("Loading...")
+
+			ReactNoop.act(function()
+				resolveText("Final")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Final" })
+			jestExpect(root).toMatchRenderedOutput("Final")
+		end
+	)
+
+	it(
+		"if there are multiple useDeferredValues in the same tree, only the first level defers; subsequent ones go straight to the final value, to avoid a waterfall",
+		function()
+			local Content
+			local function App()
+				local showContent = useDeferredValue(true, false)
+				if not showContent then
+					return React.createElement(Text, { text = "App Preview" })
+				end
+				return React.createElement(Content)
+			end
+
+			Content = function()
+				local text = useDeferredValue("Content", "Content Preview")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			resolveText("App Preview")
+
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"App Preview",
+				"Suspend! [Content]",
+			})
+			jestExpect(root).toMatchRenderedOutput("App Preview")
+
+			ReactNoop.act(function()
+				resolveText("Content")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Content" })
+			jestExpect(root).toMatchRenderedOutput("Content")
+		end
+	)
+
+	it(
+		"regression: useDeferredValue's initial value argument works even if an unrelated transition is suspended",
+		function()
+			local function Content(props)
+				local text =
+					useDeferredValue(props.text, "Preview " .. props.text .. "...")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local function App(props)
+				return React.createElement(Content, {
+					key = props.text,
+					text = props.text,
+				})
+			end
+
+			local root = ReactNoop.createRoot()
+
+			resolveText("Preview A...")
+			ReactNoop.act(function()
+				startTransition(function()
+					root.render(React.createElement(App, { text = "A" }))
+				end)
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Preview A...",
+				"Suspend! [A]",
+			})
+
+			resolveText("Preview B...")
+			ReactNoop.act(function()
+				startTransition(function()
+					root.render(React.createElement(App, { text = "B" }))
+				end)
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Preview B...",
+				"Suspend! [B]",
+			})
+
+			ReactNoop.act(function()
+				resolveText("B")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "B" })
+			jestExpect(root).toMatchRenderedOutput("B")
+		end
+	)
+
+	it(
+		"avoids a useDeferredValue waterfall when separated by a Suspense boundary",
+		function()
+			local Content
+			local function App()
+				local showContent = useDeferredValue(true, false)
+				if not showContent then
+					return React.createElement(Text, { text = "App Preview" })
+				end
+				return React.createElement(
+					Suspense,
+					{ fallback = React.createElement(Text, { text = "Loading..." }) },
+					React.createElement(Content)
+				)
+			end
+
+			Content = function()
+				local text = useDeferredValue("Content", "Content Preview")
+				return React.createElement(AsyncText, { text = text })
+			end
+
+			local root = ReactNoop.createRoot()
+			resolveText("App Preview")
+
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"App Preview",
+				"Suspend! [Content]",
+				"Loading...",
+			})
+			jestExpect(root).toMatchRenderedOutput("Loading...")
+
+			ReactNoop.act(function()
+				resolveText("Content")
+			end)
+			jestExpect(Scheduler).toHaveYielded({ "Content" })
+			jestExpect(root).toMatchRenderedOutput("Content")
 		end
 	)
 end)

--- a/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
@@ -86,6 +86,31 @@ describe("getHighestPriorityPendingLanes", function()
 	end)
 end)
 
+describe("transition lanes", function()
+	it("cycles through each transition lane", function()
+		local firstLane = ReactFiberLane.claimNextTransitionLane()
+		local claimedLanes = { [firstLane] = true }
+
+		jestExpect(ReactFiberLane.isTransitionLane(firstLane)).toBe(true)
+		for _ = 2, 9 do
+			local lane = ReactFiberLane.claimNextTransitionLane()
+			jestExpect(ReactFiberLane.isTransitionLane(lane)).toBe(true)
+			jestExpect(claimedLanes[lane]).toBeNil()
+			claimedLanes[lane] = true
+		end
+
+		jestExpect(ReactFiberLane.claimNextTransitionLane()).toBe(firstLane)
+	end)
+
+	it("distinguishes urgent work from transition work", function()
+		local transitionLane = ReactFiberLane.claimNextTransitionLane()
+		jestExpect(ReactFiberLane.includesOnlyNonUrgentLanes(transitionLane)).toBe(true)
+		jestExpect(ReactFiberLane.includesOnlyNonUrgentLanes(ReactFiberLane.DefaultLanes)).toBe(
+			false
+		)
+	end)
+end)
+
 describe("getNextLanes", function()
 	describe("given no pending lanes", function()
 		local root

--- a/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactFiberLane.roblox.spec.lua
@@ -86,13 +86,16 @@ describe("getHighestPriorityPendingLanes", function()
 	end)
 end)
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L61-L114
+-- ROBLOX DEVIATION: These local contracts verify the reserved 7/2 update and
+-- deferred split required by React 17's smaller transition-lane family.
 describe("transition lanes", function()
-	it("cycles through each transition lane", function()
+	it("cycles through each transition update lane", function()
 		local firstLane = ReactFiberLane.claimNextTransitionLane()
 		local claimedLanes = { [firstLane] = true }
 
 		jestExpect(ReactFiberLane.isTransitionLane(firstLane)).toBe(true)
-		for _ = 2, 9 do
+		for _ = 2, 7 do
 			local lane = ReactFiberLane.claimNextTransitionLane()
 			jestExpect(ReactFiberLane.isTransitionLane(lane)).toBe(true)
 			jestExpect(claimedLanes[lane]).toBeNil()
@@ -101,6 +104,40 @@ describe("transition lanes", function()
 
 		jestExpect(ReactFiberLane.claimNextTransitionLane()).toBe(firstLane)
 	end)
+
+	it("cycles through each reserved deferred lane", function()
+		local firstLane = ReactFiberLane.claimNextTransitionDeferredLane()
+		local claimedLanes = { [firstLane] = true }
+
+		jestExpect(ReactFiberLane.includesDeferredLane(firstLane)).toBe(true)
+		for _ = 2, 2 do
+			local lane = ReactFiberLane.claimNextTransitionDeferredLane()
+			jestExpect(ReactFiberLane.includesDeferredLane(lane)).toBe(true)
+			jestExpect(claimedLanes[lane]).toBeNil()
+			claimedLanes[lane] = true
+		end
+
+		jestExpect(ReactFiberLane.claimNextTransitionDeferredLane()).toBe(firstLane)
+	end)
+
+	it(
+		"retains transition lane values and rotates both families independently",
+		function()
+			local firstUpdateLane = ReactFiberLane.claimNextTransitionLane()
+			local firstDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local secondUpdateLane = ReactFiberLane.claimNextTransitionLane()
+			local secondDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+
+			jestExpect(firstUpdateLane).toBe(0b0000000000000000010000000000000)
+			jestExpect(secondUpdateLane).toBe(bit32.lshift(firstUpdateLane, 1))
+			jestExpect(firstDeferredLane).toBe(0b0000000000100000000000000000000)
+			jestExpect(secondDeferredLane).toBe(bit32.lshift(firstDeferredLane, 1))
+
+			for _ = 3, 7 do
+				ReactFiberLane.claimNextTransitionLane()
+			end
+		end
+	)
 
 	it("distinguishes urgent work from transition work", function()
 		local transitionLane = ReactFiberLane.claimNextTransitionLane()
@@ -111,7 +148,124 @@ describe("transition lanes", function()
 	end)
 end)
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L423-L470
+-- ROBLOX DEVIATION: These local contracts reconstruct React 19's separate task
+-- lane selection when React 17 stores the spawned relationship as entanglement.
 describe("getNextLanes", function()
+	local function createRoot(pendingLanes, suspendedLanes, pingedLanes)
+		return {
+			pendingLanes = pendingLanes,
+			expiredLanes = ReactFiberLane.NoLanes,
+			suspendedLanes = suspendedLanes,
+			pingedLanes = pingedLanes,
+			entangledLanes = ReactFiberLane.NoLanes,
+			entanglements = ReactFiberLane.createLaneMap(ReactFiberLane.NoLanes),
+		}
+	end
+
+	local function entangleDeferredLane(root, deferredLane, parentLanes)
+		local index = 31 - bit32.countlz(deferredLane)
+		root.entangledLanes = ReactFiberLane.mergeLanes(root.entangledLanes, deferredLane)
+		root.entanglements[index] =
+			ReactFiberLane.mergeLanes(root.entanglements[index], parentLanes)
+	end
+
+	describe("pinged deferred tasks", function()
+		it("includes a related deferred task when its parent pings with it", function()
+			local parentLane = ReactFiberLane.SyncLane
+			local deferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pingedLanes = ReactFiberLane.mergeLanes(parentLane, deferredLane)
+			local root = createRoot(pingedLanes, pingedLanes, pingedLanes)
+			entangleDeferredLane(root, deferredLane, parentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				pingedLanes
+			)
+		end)
+
+		it("does not include a related deferred task before it pings", function()
+			local parentLane = ReactFiberLane.SyncLane
+			local deferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pendingLanes = ReactFiberLane.mergeLanes(parentLane, deferredLane)
+			local root = createRoot(pendingLanes, pendingLanes, parentLane)
+			entangleDeferredLane(root, deferredLane, parentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				parentLane
+			)
+		end)
+
+		it("does not include a deferred task related to another parent", function()
+			local selectedParentLane = ReactFiberLane.SyncLane
+			local otherParentLane =
+				bit32.band(ReactFiberLane.DefaultLanes, -ReactFiberLane.DefaultLanes)
+			local deferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pendingLanes =
+				bit32.bor(selectedParentLane, otherParentLane, deferredLane)
+			local pingedLanes =
+				ReactFiberLane.mergeLanes(selectedParentLane, deferredLane)
+			local root = createRoot(pendingLanes, pendingLanes, pingedLanes)
+			entangleDeferredLane(root, deferredLane, otherParentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				selectedParentLane
+			)
+		end)
+
+		it("preserves transition priority for a related deferred task", function()
+			local parentLane = ReactFiberLane.claimNextTransitionLane()
+			local deferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pingedLanes = ReactFiberLane.mergeLanes(parentLane, deferredLane)
+			local root = createRoot(pingedLanes, pingedLanes, pingedLanes)
+			entangleDeferredLane(root, deferredLane, parentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				pingedLanes
+			)
+			jestExpect(ReactFiberLane.returnNextLanesPriority()).toBe(
+				ReactFiberLane.TransitionPriority
+			)
+		end)
+
+		it("includes every pinged deferred task related to the parent", function()
+			local parentLane = ReactFiberLane.SyncLane
+			local firstDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local secondDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pingedLanes =
+				bit32.bor(parentLane, firstDeferredLane, secondDeferredLane)
+			local root = createRoot(pingedLanes, pingedLanes, pingedLanes)
+			entangleDeferredLane(root, firstDeferredLane, parentLane)
+			entangleDeferredLane(root, secondDeferredLane, parentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				pingedLanes
+			)
+		end)
+
+		it("excludes an unrelated pinged deferred task", function()
+			local selectedParentLane = ReactFiberLane.SyncLane
+			local otherParentLane =
+				bit32.band(ReactFiberLane.DefaultLanes, -ReactFiberLane.DefaultLanes)
+			local matchingDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local unrelatedDeferredLane = ReactFiberLane.claimNextTransitionDeferredLane()
+			local pendingLanes = bit32.bor(
+				selectedParentLane,
+				otherParentLane,
+				matchingDeferredLane,
+				unrelatedDeferredLane
+			)
+			local pingedLanes =
+				bit32.bor(selectedParentLane, matchingDeferredLane, unrelatedDeferredLane)
+			local root = createRoot(pendingLanes, pendingLanes, pingedLanes)
+			entangleDeferredLane(root, matchingDeferredLane, selectedParentLane)
+			entangleDeferredLane(root, unrelatedDeferredLane, otherParentLane)
+
+			jestExpect(ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes)).toBe(
+				ReactFiberLane.mergeLanes(selectedParentLane, matchingDeferredLane)
+			)
+		end)
+	end)
+
 	describe("given no pending lanes", function()
 		local root
 

--- a/modules/react-reconciler/src/__tests__/ReactHooks-internal.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactHooks-internal.spec.lua
@@ -1438,19 +1438,28 @@ describe("ReactHooks", function()
 		local function useStateHelper(): number
 			return React.useState(0)
 		end
+		local function useDeferredValueHelper()
+			return React.useDeferredValue(0)
+		end
+		local function useTransitionHelper()
+			return React.useTransition()
+		end
 		local orderedHooks: Array<Function> = {
 			useCallbackHelper,
 			useContextHelper,
 			useDebugValueHelper,
+			useDeferredValueHelper,
 			useEffectHelper,
 			useLayoutEffectHelper,
 			useMemoHelper,
 			useReducerHelper,
 			useRefHelper,
 			useStateHelper,
+			useTransitionHelper,
 		}
 		local hooksInList: Array<Function> = {
 			useCallbackHelper,
+			useDeferredValueHelper,
 			useEffectHelper,
 			useImperativeHandleHelper,
 			useLayoutEffectHelper,
@@ -1458,20 +1467,8 @@ describe("ReactHooks", function()
 			useReducerHelper,
 			useRefHelper,
 			useStateHelper,
+			useTransitionHelper,
 		}
-		-- ROBLOX TODO: unflag this when we implement useTransition and useDeferredValueHelper
-		if ReactGlobals.__EXPERIMENTAL__ then
-			-- local function useTransitionHelper()
-			-- 	return React.useTransition()
-			-- end
-			-- local function useDeferredValueHelper()
-			-- 	return React.useDeferredValue(0, { timeoutMs = 1000 })
-			-- end
-			-- table.insert(orderedHooks, useTransitionHelper)
-			-- table.insert(orderedHooks, useDeferredValueHelper)
-			-- table.insert(hooksInList, useTransitionHelper)
-			-- table.insert(hooksInList, useDeferredValueHelper)
-		end
 		local function formatHookNamesToMatchErrorMessage(hookNameA, hookNameB)
 			return string.format(
 				"use%s%s%s",

--- a/modules/react-reconciler/src/__tests__/ReactTransition.spec.lua
+++ b/modules/react-reconciler/src/__tests__/ReactTransition.spec.lua
@@ -1,0 +1,202 @@
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+]]
+
+local Packages = script.Parent.Parent.Parent
+local React
+local ReactNoop
+local Scheduler
+local Suspense
+local useLayoutEffect
+local useState
+local startTransition
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+local jest = JestGlobals.jest
+local jestExpect = JestGlobals.expect
+
+describe("ReactTransition", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactNoop = require(Packages.Dev.ReactNoopRenderer)
+		Scheduler = require(Packages.Scheduler)
+		Suspense = React.Suspense
+		useLayoutEffect = React.useLayoutEffect
+		useState = React.useState
+		startTransition = React.startTransition
+	end)
+
+	local function Text(props)
+		Scheduler.unstable_yieldValue(props.text)
+		return props.text
+	end
+
+	-- ROBLOX deviation: These upstream tests require the unimplemented cache API.
+	it.skip("isPending works even if called from outside an input event", function() end)
+	it.skip(
+		"when multiple transitions update the same queue, only the most recent one is allowed to finish (no intermediate states)",
+		function() end
+	)
+	it.skip(
+		"when multiple transitions update the same queue, only the most recent one is allowed to finish (no intermediate states) (classes)",
+		function() end
+	)
+	it.skip(
+		"when multiple transitions update overlapping queues, all the transitions across all the queues are entangled",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition if a new transition is scheduled",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition when something suspends and we've already bailed out on another transition in a parent",
+		function() end
+	)
+	it.skip(
+		"interrupt a refresh transition when something suspends and a parent component received an interleaved update after its queue was processed",
+		function() end
+	)
+
+	it(
+		"should render normal pri updates scheduled after transitions before transitions",
+		function()
+			local updateTransitionPri
+			local updateNormalPri
+			local function App()
+				local normalPri, setNormalPri = useState(0)
+				local transitionPri, setTransitionPri = useState(0)
+				updateTransitionPri = function()
+					startTransition(function()
+						setTransitionPri(function(n)
+							return n + 1
+						end)
+					end)
+				end
+				updateNormalPri = function()
+					setNormalPri(function(n)
+						return n + 1
+					end)
+				end
+				useLayoutEffect(function()
+					Scheduler.unstable_yieldValue("Commit")
+				end)
+
+				return React.createElement(
+					Suspense,
+					{ fallback = React.createElement(Text, { text = "Loading..." }) },
+					React.createElement(Text, {
+						text = "Transition pri: " .. tostring(transitionPri),
+					}),
+					", ",
+					React.createElement(Text, {
+						text = "Normal pri: " .. tostring(normalPri),
+					})
+				)
+			end
+
+			local root = ReactNoop.createRoot()
+			ReactNoop.act(function()
+				root.render(React.createElement(App))
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Transition pri: 0",
+				"Normal pri: 0",
+				"Commit",
+			})
+			jestExpect(root).toMatchRenderedOutput("Transition pri: 0, Normal pri: 0")
+
+			ReactNoop.act(function()
+				updateTransitionPri()
+				updateNormalPri()
+			end)
+			jestExpect(Scheduler).toHaveYielded({
+				"Transition pri: 0",
+				"Normal pri: 1",
+				"Commit",
+				"Transition pri: 1",
+				"Normal pri: 1",
+				"Commit",
+			})
+			jestExpect(root).toMatchRenderedOutput("Transition pri: 1, Normal pri: 1")
+		end
+	)
+
+	-- ROBLOX deviation: This upstream test requires the unimplemented cache API.
+	it.skip(
+		"should render normal pri updates before transition suspense retries",
+		function() end
+	)
+
+	it("should not interrupt transitions with normal pri updates", function()
+		local updateNormalPri
+		local updateTransitionPri
+		local function App()
+			local transitionPri, setTransitionPri = useState(0)
+			local normalPri, setNormalPri = useState(0)
+			updateTransitionPri = function()
+				startTransition(function()
+					setTransitionPri(function(n)
+						return n + 1
+					end)
+				end)
+			end
+			updateNormalPri = function()
+				setNormalPri(function(n)
+					return n + 1
+				end)
+			end
+			useLayoutEffect(function()
+				Scheduler.unstable_yieldValue("Commit")
+			end)
+
+			return React.createElement(
+				React.Fragment,
+				nil,
+				React.createElement(Text, {
+					text = "Transition pri: " .. tostring(transitionPri),
+				}),
+				", ",
+				React.createElement(Text, {
+					text = "Normal pri: " .. tostring(normalPri),
+				})
+			)
+		end
+
+		local root = ReactNoop.createRoot()
+		ReactNoop.act(function()
+			root.render(React.createElement(App))
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"Transition pri: 0",
+			"Normal pri: 0",
+			"Commit",
+		})
+		jestExpect(root).toMatchRenderedOutput("Transition pri: 0, Normal pri: 0")
+
+		ReactNoop.act(function()
+			updateTransitionPri()
+			jestExpect(Scheduler).toFlushAndYieldThrough({ "Transition pri: 1" })
+			updateNormalPri()
+		end)
+		jestExpect(Scheduler).toHaveYielded({
+			"Normal pri: 0",
+			"Commit",
+			"Transition pri: 1",
+			"Normal pri: 1",
+			"Commit",
+		})
+		jestExpect(root).toMatchRenderedOutput("Transition pri: 1, Normal pri: 1")
+	end)
+end)

--- a/modules/react/src/React.lua
+++ b/modules/react/src/React.lua
@@ -27,6 +27,7 @@ local ReactHooks = require(React.ReactHooks)
 local ReactMemo = require(React.ReactMemo)
 local ReactContext = require(React.ReactContext)
 local ReactLazy = require(React.ReactLazy)
+local ReactStartTransition = require(React.ReactStartTransition)
 type LazyComponent<T, P> = ReactLazy.LazyComponent<T, P>
 
 -- ROBLOX DEVIATION: Bindings
@@ -107,6 +108,9 @@ return {
 	-- ROBLOX deviation: bindings support
 	useBinding = ReactHooks.useBinding,
 	useState = ReactHooks.useState,
+	useTransition = ReactHooks.useTransition,
+	useDeferredValue = ReactHooks.useDeferredValue,
+	startTransition = ReactStartTransition.startTransition,
 	--[[
 		Lets you group elements without a wrapper node.
 
@@ -135,9 +139,6 @@ return {
 	-- Deprecated behind disableCreateFactory
 	-- ROBLOX TODO: createFactory,
 	-- Concurrent Mode
-	-- ROBLOX TODO: useTransition,
-	-- ROBLOX TODO: startTransition,
-	-- ROBLOX TODO: useDeferredValue,
 	-- ROBLOX TODO: REACT_SUSPENSE_LIST_TYPE as SuspenseList,
 	unstable_LegacyHidden = ReactSymbols.REACT_LEGACY_HIDDEN_TYPE,
 	-- enableBlocksAPI

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -41,10 +41,7 @@ local ReactCurrentDispatcher =
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 
 -- ROBLOX FIXME Luau: we shouldn't need to explicitly annotate this
 local function resolveDispatcher(): Dispatcher

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -41,6 +41,10 @@ local ReactCurrentDispatcher =
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 -- ROBLOX FIXME Luau: we shouldn't need to explicitly annotate this
 local function resolveDispatcher(): Dispatcher
@@ -289,17 +293,17 @@ exports.useDebugValue = useDebugValue
 
 exports.emptyObject = {}
 
--- ROBLOX TODO: enable useTransition later
--- exports.useTransition = function(): ((() -> ()) -> (), boolean)
--- 	local dispatcher = resolveDispatcher()
--- 	return dispatcher.useTransition()
--- end
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactHooks.js#L164-L176
+-- ROBLOX deviation: Luau represents the tuple as multiple return values.
+exports.useTransition = function(): (boolean, StartTransition)
+	local dispatcher = resolveDispatcher()
+	return dispatcher.useTransition()
+end
 
--- ROBLOX TODO: enable useDeferredValue later
--- exports.useDeferredValue = function<T>(value: T): T
--- 	local dispatcher = resolveDispatcher()
--- 	return dispatcher.useDeferredValue(value)
--- end
+exports.useDeferredValue = function<T>(value: T): T
+	local dispatcher = resolveDispatcher()
+	return dispatcher.useDeferredValue(value)
+end
 
 exports.useOpaqueIdentifier = function(): OpaqueIDType | nil
 	local dispatcher = resolveDispatcher()

--- a/modules/react/src/ReactHooks.lua
+++ b/modules/react/src/ReactHooks.lua
@@ -297,9 +297,11 @@ exports.useTransition = function(): (boolean, StartTransition)
 	return dispatcher.useTransition()
 end
 
-exports.useDeferredValue = function<T>(value: T): T
+-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react/src/ReactHooks.js#L178-L180
+-- ROBLOX DEVIATION: Luau cannot distinguish an omitted argument from explicit nil.
+exports.useDeferredValue = function<T>(value: T, initialValue: T?): T
 	local dispatcher = resolveDispatcher()
-	return dispatcher.useDeferredValue(value)
+	return dispatcher.useDeferredValue(value, initialValue)
 end
 
 exports.useOpaqueIdentifier = function(): OpaqueIDType | nil

--- a/modules/react/src/ReactStartTransition.lua
+++ b/modules/react/src/ReactStartTransition.lua
@@ -1,0 +1,62 @@
+--!strict
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactStartTransition.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+]]
+
+local Packages = script.Parent.Parent
+local ReactGlobals = require(Packages.ReactGlobals)
+local LuauPolyfill = require(Packages.LuauPolyfill)
+local Set = LuauPolyfill.Set
+local console = require(Packages.Shared).console
+local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
+local ReactCurrentBatchConfig =
+	require(Packages.Shared).ReactSharedInternals.ReactCurrentBatchConfig
+
+export type StartTransitionOptions = {
+	name: string?,
+}
+
+local function startTransition(scope: () -> (), options: StartTransitionOptions?): ()
+	local prevTransition = ReactCurrentBatchConfig.transition
+	ReactCurrentBatchConfig.transition = {}
+	local currentTransition = ReactCurrentBatchConfig.transition
+
+	if ReactGlobals.__DEV__ then
+		currentTransition._updatedFibers = Set.new()
+	end
+
+	if ReactFeatureFlags.enableTransitionTracing then
+		if options ~= nil and options.name ~= nil then
+			currentTransition.name = options.name
+			currentTransition.startTime = -1
+		end
+	end
+
+	local ok, result = pcall(scope)
+	ReactCurrentBatchConfig.transition = prevTransition
+
+	if ReactGlobals.__DEV__ and currentTransition._updatedFibers ~= nil then
+		if prevTransition == nil and currentTransition._updatedFibers.size > 10 then
+			console.warn(
+				"Detected a large number of updates inside startTransition. "
+					.. "If this is due to a subscription please re-write it to use React provided hooks. "
+					.. "Otherwise concurrent mode guarantees are off the table."
+			)
+		end
+		currentTransition._updatedFibers:clear()
+	end
+
+	if not ok then
+		error(result)
+	end
+end
+
+return {
+	startTransition = startTransition,
+}

--- a/modules/react/src/ReactStartTransition.lua
+++ b/modules/react/src/ReactStartTransition.lua
@@ -13,14 +13,12 @@ local Packages = script.Parent.Parent
 local ReactGlobals = require(Packages.ReactGlobals)
 local LuauPolyfill = require(Packages.LuauPolyfill)
 local Set = LuauPolyfill.Set
-local console = require(Packages.Shared).console
-local ReactFeatureFlags = require(Packages.Shared).ReactFeatureFlags
-local ReactCurrentBatchConfig =
-	require(Packages.Shared).ReactSharedInternals.ReactCurrentBatchConfig
+local ReactTypes = require(Packages.Shared)
+local console = ReactTypes.console
+local ReactFeatureFlags = ReactTypes.ReactFeatureFlags
+local ReactCurrentBatchConfig = ReactTypes.ReactSharedInternals.ReactCurrentBatchConfig
 
-export type StartTransitionOptions = {
-	name: string?,
-}
+export type StartTransitionOptions = ReactTypes.StartTransitionOptions
 
 local function startTransition(scope: () -> (), options: StartTransitionOptions?): ()
 	local prevTransition = ReactCurrentBatchConfig.transition
@@ -53,7 +51,7 @@ local function startTransition(scope: () -> (), options: StartTransitionOptions?
 	end
 
 	if not ok then
-		error(result)
+		error(result, 0)
 	end
 end
 

--- a/modules/react/src/__tests__/ReactStartTransition.spec.lua
+++ b/modules/react/src/__tests__/ReactStartTransition.spec.lua
@@ -1,0 +1,97 @@
+--!strict
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/__tests__/ReactStartTransition-test.js
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+]]
+
+local Packages = script.Parent.Parent.Parent
+
+local React
+local ReactTestRenderer
+local act
+local useState
+local useTransition
+
+local LuauPolyfill = require(Packages.LuauPolyfill)
+local Set = LuauPolyfill.Set
+
+local JestGlobals = require(Packages.Dev.JestGlobals)
+local jestExpect = JestGlobals.expect
+local jest = JestGlobals.jest
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local it = JestGlobals.it
+
+local SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED = 10
+
+describe("ReactStartTransition", function()
+	beforeEach(function()
+		jest.resetModules()
+		React = require(Packages.React)
+		ReactTestRenderer = require(Packages.Dev.ReactTestRenderer)
+		act = ReactTestRenderer.unstable_concurrentAct
+		useState = React.useState
+		useTransition = React.useTransition
+	end)
+
+	it("Warns if a suspicious number of fibers are updated inside startTransition", function()
+		local subs = Set.new()
+		local function useUserSpaceSubscription()
+			local _, setState = useState(0)
+			subs:add(setState)
+		end
+
+		local triggerHookTransition
+		local Component
+		Component = function(props)
+			useUserSpaceSubscription()
+			if props.level == 0 then
+				local _, start = useTransition()
+				triggerHookTransition = start
+			end
+			if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
+				return React.createElement(Component, { level = props.level + 1 })
+			end
+			return nil
+		end
+
+		act(function()
+			ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+				unstable_isConcurrent = true,
+			})
+		end)
+
+		local warning = "Detected a large number of updates inside startTransition. "
+			.. "If this is due to a subscription please re-write it to use React provided hooks. "
+			.. "Otherwise concurrent mode guarantees are off the table."
+
+		jestExpect(function()
+			act(function()
+				React.startTransition(function()
+					subs:forEach(function(setState)
+						setState(function(state)
+							return state + 1
+						end)
+					end)
+				end)
+			end)
+		end).toWarnDev({ warning }, { withoutStack = true })
+
+		jestExpect(function()
+			act(function()
+				triggerHookTransition(function()
+					subs:forEach(function(setState)
+						setState(function(state)
+							return state + 1
+						end)
+					end)
+				end)
+			end)
+		end).toWarnDev({ warning }, { withoutStack = true })
+	end)
+end)

--- a/modules/react/src/__tests__/ReactStartTransition.spec.lua
+++ b/modules/react/src/__tests__/ReactStartTransition.spec.lua
@@ -39,59 +39,95 @@ describe("ReactStartTransition", function()
 		useTransition = React.useTransition
 	end)
 
-	it("Warns if a suspicious number of fibers are updated inside startTransition", function()
-		local subs = Set.new()
-		local function useUserSpaceSubscription()
-			local _, setState = useState(0)
-			subs:add(setState)
+	it(
+		"Warns if a suspicious number of fibers are updated inside startTransition",
+		function()
+			local subs = Set.new()
+			local function useUserSpaceSubscription()
+				local _, setState = useState(0)
+				subs:add(setState)
+			end
+
+			local triggerHookTransition
+			local Component
+			Component = function(props)
+				useUserSpaceSubscription()
+				if props.level == 0 then
+					local _, start = useTransition()
+					triggerHookTransition = start
+				end
+				if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
+					return React.createElement(Component, { level = props.level + 1 })
+				end
+				return nil
+			end
+
+			act(function()
+				ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+					unstable_isConcurrent = true,
+				})
+			end)
+
+			local warning = "Detected a large number of updates inside startTransition. "
+				.. "If this is due to a subscription please re-write it to use React provided hooks. "
+				.. "Otherwise concurrent mode guarantees are off the table."
+
+			jestExpect(function()
+				act(function()
+					React.startTransition(function()
+						subs:forEach(function(setState)
+							setState(function(state)
+								return state + 1
+							end)
+						end)
+					end)
+				end)
+			end).toWarnDev({ warning }, { withoutStack = true })
+
+			jestExpect(function()
+				act(function()
+					triggerHookTransition(function()
+						subs:forEach(function(setState)
+							setState(function(state)
+								return state + 1
+							end)
+						end)
+					end)
+				end)
+			end).toWarnDev({ warning }, { withoutStack = true })
 		end
+	)
+
+	it("preserves errors thrown by transition callbacks", function()
+		local globalSucceeded, globalError = pcall(function()
+			React.startTransition(function()
+				error("global transition failure", 0)
+			end)
+		end)
+		jestExpect(globalSucceeded).toBe(false)
+		jestExpect(globalError).toBe("global transition failure")
 
 		local triggerHookTransition
-		local Component
-		Component = function(props)
-			useUserSpaceSubscription()
-			if props.level == 0 then
-				local _, start = useTransition()
-				triggerHookTransition = start
-			end
-			if props.level < SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED then
-				return React.createElement(Component, { level = props.level + 1 })
-			end
+		local function Component()
+			local _, start = useTransition()
+			triggerHookTransition = start
 			return nil
 		end
 
 		act(function()
-			ReactTestRenderer.create(React.createElement(Component, { level = 0 }), {
+			ReactTestRenderer.create(React.createElement(Component), {
 				unstable_isConcurrent = true,
 			})
 		end)
 
-		local warning = "Detected a large number of updates inside startTransition. "
-			.. "If this is due to a subscription please re-write it to use React provided hooks. "
-			.. "Otherwise concurrent mode guarantees are off the table."
-
-		jestExpect(function()
-			act(function()
-				React.startTransition(function()
-					subs:forEach(function(setState)
-						setState(function(state)
-							return state + 1
-						end)
-					end)
-				end)
-			end)
-		end).toWarnDev({ warning }, { withoutStack = true })
-
-		jestExpect(function()
+		local hookSucceeded, hookError = pcall(function()
 			act(function()
 				triggerHookTransition(function()
-					subs:forEach(function(setState)
-						setState(function(state)
-							return state + 1
-						end)
-					end)
+					error("hook transition failure", 0)
 				end)
 			end)
-		end).toWarnDev({ warning }, { withoutStack = true })
+		end)
+		jestExpect(hookSucceeded).toBe(false)
+		jestExpect(hookError).toBe("hook transition failure")
 	end)
 end)

--- a/modules/shared/src/ReactFeatureFlags.lua
+++ b/modules/shared/src/ReactFeatureFlags.lua
@@ -155,4 +155,8 @@ exports.enableEagerRootListeners = false
 
 exports.enableDoubleInvokingEffects = false
 
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/shared/forks/ReactFeatureFlags.www.js
+-- ROBLOX deviation: Transition tracing is not available in React Lua.
+exports.enableTransitionTracing = false
+
 return exports

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
@@ -13,7 +13,14 @@
  * Keeps track of the current batch's configuration such as how long an update
  * should suspend for if it needs to.
 ]]
-local ReactCurrentBatchConfig = {
+local ReactTypes = require(script.Parent.Parent.ReactTypes)
+type BatchConfigTransition = ReactTypes.BatchConfigTransition
+
+type BatchConfig = {
+	transition: BatchConfigTransition?,
+}
+
+local ReactCurrentBatchConfig: BatchConfig = {
 	transition = nil,
 }
 

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentBatchConfig.lua
@@ -1,5 +1,5 @@
 --!strict
--- ROBLOX upstream: https://github.com/facebook/react/blob/92fcd46cc79bbf45df4ce86b0678dcef3b91078d/packages/react/src/ReactCurrentBatchConfig.js
+-- ROBLOX upstream: https://github.com/facebook/react/blob/34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d/packages/react/src/ReactCurrentBatchConfig.js
 --[[*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -14,7 +14,7 @@
  * should suspend for if it needs to.
 ]]
 local ReactCurrentBatchConfig = {
-	transition = 0,
+	transition = nil,
 }
 
 return ReactCurrentBatchConfig

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -39,6 +39,10 @@ type MutableSourceGetSnapshotFn<Source, Snapshot> = ReactTypes.MutableSourceGetS
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
+type StartTransitionOptions = {
+	name: string?,
+}
+type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
 
 export type Dispatcher = {
 	readContext: <T>(
@@ -77,9 +81,9 @@ export type Dispatcher = {
 		deps: Array<any> | nil
 	) -> (),
 	useDebugValue: <T>(value: T, formatterFn: ((value: T) -> any)?) -> (),
-	-- ROBLOX TODO: make these non-optional and implement them in the dispatchers
-	useDeferredValue: (<T>(value: T) -> T)?,
-	useTransition: (() -> ((() -> ()) -> (), boolean))?, -- ROBLOX deviation: Luau doesn't support jagged array types [(() -> ()) -> (), boolean],
+	useDeferredValue: <T>(value: T) -> T,
+	-- ROBLOX deviation: Luau represents React's tuple as multiple return values.
+	useTransition: () -> (boolean, StartTransition),
 	useMutableSource: <Source, Snapshot>(
 		source: MutableSource<Source>,
 		getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -39,10 +39,7 @@ type MutableSourceGetSnapshotFn<Source, Snapshot> = ReactTypes.MutableSourceGetS
 
 type BasicStateAction<S> = ((S) -> S) | S
 type Dispatch<A> = (A) -> ()
-type StartTransitionOptions = {
-	name: string?,
-}
-type StartTransition = (callback: () -> (), options: StartTransitionOptions?) -> ()
+type StartTransition = ReactTypes.StartTransition
 
 export type Dispatcher = {
 	readContext: <T>(

--- a/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
+++ b/modules/shared/src/ReactSharedInternals/ReactCurrentDispatcher.lua
@@ -78,7 +78,8 @@ export type Dispatcher = {
 		deps: Array<any> | nil
 	) -> (),
 	useDebugValue: <T>(value: T, formatterFn: ((value: T) -> any)?) -> (),
-	useDeferredValue: <T>(value: T) -> T,
+	-- ROBLOX upstream: https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactInternalTypes.js#L430
+	useDeferredValue: <T>(value: T, initialValue: T?) -> T,
 	-- ROBLOX deviation: Luau represents React's tuple as multiple return values.
 	useTransition: () -> (boolean, StartTransition),
 	useMutableSource: <Source, Snapshot>(

--- a/modules/shared/src/ReactTypes.lua
+++ b/modules/shared/src/ReactTypes.lua
@@ -21,6 +21,21 @@ type React_Node = flowtypes.React_Node
 type SimpleMap<K, V> = { [K]: V }
 type Iterable<T> = SimpleMap<string | number, T> | Array<T>
 
+export type BatchConfigTransition = {
+	_updatedFibers: any?,
+	name: string?,
+	startTime: number?,
+}
+
+export type StartTransitionOptions = {
+	name: string?,
+}
+
+export type StartTransition = (
+	callback: () -> (),
+	options: StartTransitionOptions?
+) -> ()
+
 export type ReactNode<T = any> =
 	React_Element<T>
 	| ReactPortal

--- a/modules/shared/src/init.lua
+++ b/modules/shared/src/init.lua
@@ -29,6 +29,9 @@ local ErrorHandling = require(script["ErrorHandling.roblox"])
 
 -- Re-export all top-level public types
 export type ReactEmpty = ReactTypes.ReactEmpty
+export type BatchConfigTransition = ReactTypes.BatchConfigTransition
+export type StartTransitionOptions = ReactTypes.StartTransitionOptions
+export type StartTransition = ReactTypes.StartTransition
 export type ReactFragment = ReactTypes.ReactFragment
 export type ReactNodeList = ReactTypes.ReactNodeList
 export type ReactProviderType<T> = ReactTypes.ReactProviderType<T>


### PR DESCRIPTION
## Summary

Backport React 19.2's optional initialValue argument for useDeferredValue on top of #25.

The first render can commit the supplied preview immediately and then schedule the final value as a distinct deferred task. The port also includes the behavior needed to recover suspended previews, avoid nested deferred waterfalls, and preserve the existing one-argument React 18 contract.

React Debug Tools includes the #28508 correction: inspection logs and returns the committed deferred value so the inspected component follows the committed tree's control flow and every subsequent hook stays aligned.

## Dependency and consolidation

- Depends on #25 and must merge after it. This branch is based directly on commit c6ce5642dc9e1881772a23fb0d01dd3a09162f61.
- #32 owns the client `use` API and `ReactFiberThenable`, including the development/production thenable-state split. This PR neither depends on nor duplicates that separate backport; Anime Rush composes both standalone ports during integration.
- #28 shares the current-Luau stack parser, missing-ancestor guard, scalar/nil Memo normalization, nil-useMemo regression, and non-optimized Debug Tools test fixture. Whichever PR merges second must drop those duplicate hunks.
- #34 shares the component-wakeable boundaryless-suspension substrate. Spawned-deferred recovery remains specific to this PR. #34 additionally handles Action wakeables thrown by a HostRoot, so consolidation must retain that non-byte-identical extension. Both PRs use the same marked React 17 JND timer adaptation in tests.
- This PR stays draft until its dependency and shared-hunk consolidation are resolved.

## Upstream source and test ledger

Pinned stable contract: [React v19.2.0](https://github.com/facebook/react/tree/ae74234eae6ebd62f19190731278e20bc1c37d51).

| Upstream source or test | React-Luau target | Status and deviation |
| --- | --- | --- |
| [Public hook](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react/src/ReactHooks.js#L178-L180) and [dispatcher type](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactInternalTypes.js#L430) | ReactHooks.lua; ReactCurrentDispatcher.lua | Direct. Luau cannot distinguish an omitted argument from explicit nil. |
| [Hook implementation](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberHooks.js#L2963-L3080) and seven DEV dispatchers | ReactFiberHooks.new.lua | Adapted to React 17's lane layout. Hidden-tree/Activity prerendering is unavailable and marked at the source site. |
| [Deferred-lane request](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L852-L914) | ReactFiberWorkLoop.new.lua | React 17 has no identity-valued Suspense handler stack. The port reconstructs the exact boundary selected by its canonical throw path using the visibility cursor and shouldCaptureSuspense predicate, including fallback-subtree and unstable_avoidThisFallback semantics. |
| [Deferred lane families and root bookkeeping](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L61-L114) | ReactFiberLane.lua | React 17's nine transition bits keep their numeric values. Seven remain update lanes and the two highest form an independently rotating deferred family. |
| [Separate task and entangled render lanes](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberLane.js#L423-L470) | ReactFiberLane.lua | React 17 collapses those sets. A constrained reverse selection chooses a pinged deferred task only when its stored entangled parent is also selected and pinged; priority is unchanged. |
| [DidDefer recovery](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberBeginWork.js#L2324-L2582) and [DidDefer flag](https://github.com/facebook/react/blob/61cde7820e72fa6e922de2434988fcbdc971710b/packages/react-reconciler/src/ReactFiberFlags.js#L44) | ReactFiberBeginWork.new.lua; ReactFiberFlags.lua | Direct behavior with site-level register-limit and mutually-exclusive flag-reuse deviations. Hydration-only branches are unavailable. |
| [Boundaryless component suspension](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberThrow.js#L524-L537) and [HostRoot unwind](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberUnwindWork.js#L92-L115) | ReactFiberThrow.new.lua; ReactFiberUnwindWork.new.lua | Adapted prerequisite for concurrent roots. Interrupted mounted Fibers restore from alternates; new suspended mounts retain hook state. |
| [Concurrent finish and commit readiness](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1342-L1615) | ReactFiberWorkLoop.new.lua | React 17 folds the modern helpers together and explicitly threads spawnedLane through concurrent and separate sync paths. |
| [Debug Tools implementation](https://github.com/facebook/react/blob/7268dacf70cd6a7f5705a19053aad46b5289ab72/packages/react-debug-tools/src/ReactDebugHooks.js#L445-L456) | ReactDebugHooks.lua | Returns the committed memoized value. React 19 debugInfo and hookSource schema fields are not available in this React 17 Debug Tools model and are marked at the test site. |
| [Public deferred-value cases](https://github.com/facebook/react/blob/ae74234eae6ebd62f19190731278e20bc1c37d51/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js#L374-L697) | ReactDeferredValue.spec.lua | All renderer-supported cases remain in upstream order. React 19 sibling-prewarming duplicate logs are omitted because React 17 does not prewarm siblings. |
| [Debug Tools #28508 regression](https://github.com/facebook/react/blob/7268dacf70cd6a7f5705a19053aad46b5289ab72/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js#L1209-L1465) | ReactHooksInspectionIntegration.spec.lua | Preserves initial, pending, and final rendered output; State; DeferredValue; conditional Context; and both trailing Memo assertions. The slotless renderer read and inspection dispatcher read are inlined so the translation adds no custom-hook frame. React 17 StrictMode replay, synchronous act, Promise construction, one-based IDs, and option naming are marked locally. |
| React 17 handler reconstruction | ReactDeferredValue.spec.lua | Two local regressions prove a deferred hook in a fallback marks the outer catcher and an avoided inner boundary selects the desirable outer catcher. |
| Reserved-lane contract | ReactFiberLane.roblox.spec.lua | Six local cases cover matching, unpinged, unrelated-parent, transition-priority, and multiple-deferred selection. |
| Fizz, hydration, Activity/Offscreen hidden prerendering, and browser popstate tests | No target | Out of scope because React-Luau exposes none of those renderer contracts on this branch. |

Behavior-bearing history includes [#27500](https://github.com/facebook/react/pull/27500), [#27509](https://github.com/facebook/react/pull/27509), [#27512](https://github.com/facebook/react/pull/27512), [#27888](https://github.com/facebook/react/pull/27888), [#28508](https://github.com/facebook/react/commit/7268dacf70cd6a7f5705a19053aad46b5289ab72), [#32821](https://github.com/facebook/react/pull/32821), and [#34376](https://github.com/facebook/react/pull/34376).

## Test-driven regressions

- Before deferred-task reverse selection, the boundaryless recovery case retained the suspended preview yield before Final.
- Before canonical Suspense capture selection, the fallback-subtree case stopped after Primary, Loading, and Outer Fallback instead of attempting Primary and Final again.
- Before canonical avoided-boundary selection, the desirable-boundary case stopped after Loading and Outer Fallback instead of attempting Final.
- Before the React 17 StrictMode setter adaptation, the #28508 test dispatched into the abandoned mount queue and never produced the pending tree.

Each failing state was reproduced before its corresponding implementation and the assertions were retained.

## Verification

Exact candidate:

- Commit: dcd03505352a3349c939d744fd1294ad616dbd9f
- Tree: 6eef706509b8354de08fc0c965a17e5e98192f10
- One commit on dependency head c6ce5642dc9e1881772a23fb0d01dd3a09162f61
- Archived source snapshot SHA-256: D50B88BE6EB1E7D7BB99F68CE146504027CDF1FDED02CF8E13BA194F8EA5619E

Static checks:

- StyLua 0.18.1 check: passed on all 13 changed Luau files
- luau-compile: passed on all 13 changed Luau files
- Selene 0.28.0: 0 errors, 0 warnings, 0 parse errors
- git diff --check and privacy/debug-residue audit: passed
- Independent provenance, deviation, ancestry, attribution, and source-link audit: passed

Hardened single-runtime Studio CLI:

- Package identity: 1/1
- ReactDeferredValue: 15/15
- ReactFiberLane: 53/53
- ReactHooksInspectionIntegration: 17 passed, 3 pre-existing skipped
- Focused #28508 regression: 1/1
- Focused nil-useMemo regression: 1/1
- Focused fallback-subtree handler regression: 1/1
- Focused desirable-boundary regression: 1/1

Generated with Codex.
